### PR TITLE
Add reusable team grid with modal bios

### DIFF
--- a/src/components/TeamGrid.astro
+++ b/src/components/TeamGrid.astro
@@ -1,0 +1,205 @@
+---
+import type { TeamMember } from '../data/team';
+
+const { members } = Astro.props as { members: TeamMember[] };
+
+const iconMap: Record<string, string> = {
+  instagram:
+    '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current" focusable="false"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 1.366.062 2.633.35 3.608 1.325.975.975 1.263 2.242 1.325 3.608.058 1.266.07 1.646.07 4.85s-.012 3.584-.07 4.85c-.062 1.366-.35 2.633-1.325 3.608-.975.975-2.242 1.263-3.608 1.325-1.266.058-1.646.07-4.85.07s-3.584-.012-4.85-.07c-1.366-.062-2.633-.35-3.608-1.325-.975-.975-1.263-2.242-1.325-3.608C2.175 15.584 2.163 15.204 2.163 12s.012-3.584.07-4.85c.062-1.366.35-2.633 1.325-3.608C4.533 2.567 5.8 2.279 7.166 2.217 8.432 2.159 8.812 2.147 12 2.147m0-2.147C8.741 0 8.332.014 7.052.072 5.775.13 4.638.428 3.678 1.388c-.96.96-1.258 2.097-1.316 3.374C2.304 6.042 2.29 6.451 2.29 9.71v4.58c0 3.259.014 3.668.072 4.948.058 1.277.356 2.414 1.316 3.374.96.96 2.097 1.258 3.374 1.316 1.28.058 1.689.072 4.948.072s3.668-.014 4.948-.072c1.277-.058 2.414-.356 3.374-1.316.96-.96 1.258-2.097 1.316-3.374.058-1.28.072-1.689.072-4.948V9.71c0-3.259-.014-3.668-.072-4.948-.058-1.277-.356-2.414-1.316-3.374C19.362.428 18.225.13 16.948.072 15.668.014 15.259 0 12 0z"/><path d="M12 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zm0 10.176a4.014 4.014 0 1 1 0-8.028 4.014 4.014 0 0 1 0 8.028z"/><circle cx="18.406" cy="5.595" r="1.44"/></svg>',
+  facebook:
+    '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current" focusable="false"><path d="M22.675 0H1.325C.593 0 0 .593 0 1.326v21.348C0 23.407.593 24 1.325 24H12.82v-9.294H9.692V11.09h3.128V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.794.143v3.24l-1.918.001c-1.504 0-1.796.715-1.796 1.764v2.313h3.587l-.467 3.616h-3.12V24h6.116C23.407 24 24 23.407 24 22.674V1.326C24 .593 23.407 0 22.675 0z"/></svg>',
+  linkedin:
+    '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current" focusable="false"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.026-3.037-1.852-3.037-1.853 0-2.136 1.447-2.136 2.941v5.665H9.351V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.602 0 4.268 2.371 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>',
+  twitter:
+    '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current" focusable="false"><path d="M23.954 4.569a10 10 0 0 1-2.825.775 4.932 4.932 0 0 0 2.163-2.724 9.864 9.864 0 0 1-3.127 1.196 4.916 4.916 0 0 0-8.38 4.482A13.94 13.94 0 0 1 1.671 3.149a4.822 4.822 0 0 0-.666 2.475 4.92 4.92 0 0 0 2.188 4.096 4.903 4.903 0 0 1-2.229-.616v.062a4.923 4.923 0 0 0 3.946 4.827 4.996 4.996 0 0 1-2.224.084 4.936 4.936 0 0 0 4.604 3.417A9.867 9.867 0 0 1 .96 19.54a13.94 13.94 0 0 0 7.548 2.212c9.057 0 14.01-7.496 14.01-13.986 0-.21 0-.423-.015-.633A9.936 9.936 0 0 0 24 4.59z"/></svg>',
+  web:
+    '<svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current" focusable="false"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm6.92 9h-2.83a15.47 15.47 0 0 0-1.36-5.11 8.02 8.02 0 0 1 4.19 5.11zM12 4a13.4 13.4 0 0 1 1.9 5h-3.8A13.4 13.4 0 0 1 12 4zM7.27 14a15.24 15.24 0 0 1 0-4h4.46v4H7.27zm2.43 2h2.2a13.42 13.42 0 0 1-1.1 4 13.42 13.42 0 0 1-1.1-4zM7.1 9a13.42 13.42 0 0 1 1.1-4 13.42 13.42 0 0 1 1.1 4H7.1zm6.2 7h2.2a13.42 13.42 0 0 1-1.1 4 13.42 13.42 0 0 1-1.1-4zm0-9a13.42 13.42 0 0 1 1.1-4 13.42 13.42 0 0 1 1.1 4h-2.2zM6.27 5.89A15.47 15.47 0 0 0 4.65 10H1.92a8.02 8.02 0 0 1 4.35-4.11zM1.92 14h2.73a15.47 15.47 0 0 0 1.62 4.11A8.02 8.02 0 0 1 1.92 14zm13.77 4.11A15.47 15.47 0 0 0 16.09 14h2.83a8.02 8.02 0 0 1-4.23 4.11z"/></svg>'
+};
+
+const serializedMembers = members.map((member) => ({
+  ...member,
+  socials: member.socials.map((social) => ({
+    ...social,
+    icon: iconMap[social.platform] ?? ''
+  }))
+}));
+---
+<div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-4" data-team-grid>
+  {members.map((member, index) => (
+    <button
+      type="button"
+      class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-accent-blush/40 bg-white/90 text-left shadow-lg transition focus:outline-none focus-visible:ring-4 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+      data-member-index={index}
+    >
+      <div class="relative h-72 w-full overflow-hidden">
+        <img
+          src={member.image}
+          alt={`Retrato de ${member.name}`}
+          loading={index === 0 ? 'eager' : 'lazy'}
+          class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+        />
+        <div class="absolute inset-0 bg-gradient-to-t from-primary-dark/80 via-primary-dark/40 to-transparent"></div>
+        <div class="absolute inset-x-0 bottom-0 space-y-2 p-6 text-white">
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-accent/80">{member.role}</p>
+          <h3 class="text-2xl font-semibold leading-snug">{member.name}</h3>
+        </div>
+      </div>
+      <div class="flex flex-1 flex-col justify-between gap-4 p-6">
+        <p class="text-sm text-neutral-black/80 leading-relaxed">{member.shortBio}</p>
+        <div class="space-y-3">
+          <div class="rounded-2xl bg-accent-flamingo/10 px-4 py-3 text-xs font-medium text-primary-dark/80">
+            {member.focus}
+          </div>
+          <span class="inline-flex items-center gap-2 text-sm font-semibold text-primary-dark transition-colors group-hover:text-accent">
+            Ver perfil
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M7.293 4.293a1 1 0 0 1 1.414 0l5 5a1 1 0 0 1 0 1.414l-5 5a1 1 0 1 1-1.414-1.414L10.586 11H4a1 1 0 0 1 0-2h6.586L7.293 5.707a1 1 0 0 1 0-1.414z" />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </button>
+  ))}
+</div>
+
+<div
+  class="team-modal fixed inset-0 z-50 hidden place-items-center bg-primary-dark/80 p-4 backdrop-blur"
+  data-team-modal
+  aria-hidden="true"
+>
+  <div
+    class="pointer-events-auto relative w-full max-w-4xl overflow-hidden rounded-3xl bg-white shadow-2xl"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="team-modal-title"
+  >
+    <button
+      type="button"
+      class="absolute right-4 top-4 rounded-full bg-primary-dark/5 p-2 text-primary-dark transition hover:bg-primary-dark/10 focus:outline-none focus-visible:ring-4 focus-visible:ring-accent"
+      data-team-close
+      aria-label="Cerrar detalle de integrante"
+    >
+      <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path
+          fill-rule="evenodd"
+          d="M4.293 4.293a1 1 0 0 1 1.414 0L10 8.586l4.293-4.293a1 1 0 1 1 1.414 1.414L11.414 10l4.293 4.293a1 1 0 0 1-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L8.586 10 4.293 5.707a1 1 0 0 1 0-1.414z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </button>
+    <div class="grid gap-8 md:grid-cols-[minmax(0,_0.95fr)_minmax(0,_1.3fr)]">
+      <div class="relative h-80 w-full overflow-hidden bg-neutral/20 md:h-full">
+        <img
+          data-team-image
+          alt="Retrato del equipo"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        />
+        <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-primary-dark/80 via-transparent to-transparent p-6 text-white">
+          <p class="text-xs font-semibold uppercase tracking-[0.25em] text-accent/80" data-team-role></p>
+          <h3 id="team-modal-title" class="text-2xl font-semibold leading-snug" data-team-name></h3>
+        </div>
+      </div>
+      <div class="flex flex-col gap-6 p-8">
+        <p class="text-base leading-relaxed text-neutral-black/80" data-team-bio></p>
+        <div>
+          <h4 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-dark/80">Enfoque</h4>
+          <p class="mt-2 rounded-2xl bg-accent-flamingo/10 px-4 py-3 text-sm font-medium text-primary-dark/90" data-team-focus></p>
+        </div>
+        <div>
+          <h4 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-dark/80">Conecta</h4>
+          <div class="mt-3 flex flex-wrap gap-3" data-team-socials></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="application/json" id="team-data">{JSON.stringify(serializedMembers)}</script>
+<script>
+  const dataElement = document.getElementById('team-data');
+  if (!dataElement) {
+    console.warn('No se encontró la información del equipo.');
+  } else {
+    const members = JSON.parse(dataElement.textContent || '[]');
+    const modal = document.querySelector('[data-team-modal]');
+    const closeButtons = modal?.querySelectorAll('[data-team-close]');
+    const image = modal?.querySelector('[data-team-image]');
+    const name = modal?.querySelector('[data-team-name]');
+    const role = modal?.querySelector('[data-team-role]');
+    const bio = modal?.querySelector('[data-team-bio]');
+    const focus = modal?.querySelector('[data-team-focus]');
+    const socials = modal?.querySelector('[data-team-socials]');
+    let activeTrigger = null;
+
+    const openModal = (member) => {
+      if (!modal || !image || !name || !role || !bio || !focus || !socials) return;
+      image.src = member.image;
+      image.alt = `Retrato de ${member.name}`;
+      name.textContent = member.name;
+      role.textContent = member.role;
+      bio.textContent = member.bio;
+      focus.textContent = member.focus;
+      socials.innerHTML = '';
+      member.socials.forEach((social) => {
+        const link = document.createElement('a');
+        link.href = social.url;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = 'group inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 text-sm font-semibold text-primary-dark transition hover:border-accent hover:bg-accent/10 hover:text-accent';
+        link.innerHTML = `${social.icon || ''}<span>${social.label}</span>`;
+        const icon = link.querySelector('svg');
+        if (icon) {
+          icon.classList.add('text-accent');
+        }
+        socials.appendChild(link);
+      });
+      modal.classList.remove('hidden');
+      modal.classList.add('grid');
+      modal.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('overflow-hidden');
+      const closeButton = modal.querySelector('[data-team-close]');
+      if (closeButton instanceof HTMLElement) {
+        closeButton.focus();
+      }
+    };
+
+    const closeModal = () => {
+      if (!modal) return;
+      modal.classList.add('hidden');
+      modal.classList.remove('grid');
+      modal.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('overflow-hidden');
+      if (activeTrigger instanceof HTMLElement) {
+        activeTrigger.focus();
+      }
+      activeTrigger = null;
+    };
+
+    document.querySelectorAll('[data-member-index]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const index = Number(button.getAttribute('data-member-index'));
+        const member = members[index];
+        if (!member) return;
+        activeTrigger = button;
+        openModal(member);
+      });
+    });
+
+    closeButtons?.forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+
+    modal?.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal();
+      }
+    });
+  }
+</script>

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -1,43 +1,104 @@
+export type SocialPlatform = 'instagram' | 'facebook' | 'linkedin' | 'twitter' | 'web';
+
+export type SocialLink = {
+  platform: SocialPlatform;
+  label: string;
+  url: string;
+};
+
 export type TeamMember = {
   name: string;
   role: string;
+  image: string;
+  shortBio: string;
   bio: string;
   focus: string;
-  image: string;
-  layout: string;
+  socials: SocialLink[];
 };
 
 export const teamMembers: TeamMember[] = [
   {
-    name: 'María Fernanda Simbaña',
-    role: 'Directora ejecutiva',
-    bio: 'Socióloga afroecuatoriana con 12 años impulsando políticas públicas y laboratorios de innovación social en territorios rurales y urbanos.',
-    focus: 'Diseña estrategias de incidencia y alianzas feministas que sostienen la red Funteco.',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/16.jpg',
-    layout: 'md:col-span-3 md:row-span-2'
+    name: 'Nieves Méndez Olaya',
+    role: 'Socia fundadora',
+    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/funtecoNieves.png',
+    shortBio:
+      'Trabajadora social con dos décadas de acompañamiento a familias afrocolombianas y ecuatorianas en procesos de cuidado comunitario.',
+    bio: 'Nieves lidera procesos de acompañamiento psicosocial y formación en derechos para mujeres migrantes afro. Ha facilitado redes de apoyo comunitario en Esmeraldas, Quito y la frontera norte, sosteniendo espacios de escucha y sanación colectiva.',
+    focus: 'Teje metodologías de cuidado y sanación colectiva.',
+    socials: [
+      {
+        platform: 'facebook',
+        label: 'Facebook de Nieves Méndez Olaya',
+        url: 'https://www.facebook.com/'
+      },
+      {
+        platform: 'instagram',
+        label: 'Instagram de Nieves Méndez Olaya',
+        url: 'https://www.instagram.com/'
+      }
+    ]
   },
   {
-    name: 'Gabriela Hurtado',
-    role: 'Coordinadora de investigación comunitaria',
-    bio: 'Periodista y maestra en derechos humanos. Lidera procesos participativos para mapear memorias afro y narrativas de movilidad.',
-    focus: 'Guía metodologías colaborativas y cuida el archivo vivo de las comunidades aliadas.',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/13.jpg',
-    layout: 'md:col-span-3'
+    name: 'Diana Angulo Balanta',
+    role: 'Socia fundadora',
+    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/funtecoDiana.png',
+    shortBio:
+      'Comunicadora y gestora cultural afrocolombiana. Impulsa procesos de memoria y narrativas audiovisuales con juventudes afro.',
+    bio: 'Diana dinamiza talleres de comunicación popular y proyectos audiovisuales que rescatan historias afro en Ecuador y Colombia. Coordina alianzas con festivales comunitarios y acompaña a liderazgos juveniles en el uso estratégico de medios digitales.',
+    focus: 'Potencia la comunicación comunitaria y la memoria audiovisual afro.',
+    socials: [
+      {
+        platform: 'instagram',
+        label: 'Instagram de Diana Angulo Balanta',
+        url: 'https://www.instagram.com/'
+      },
+      {
+        platform: 'linkedin',
+        label: 'LinkedIn de Diana Angulo Balanta',
+        url: 'https://www.linkedin.com/'
+      }
+    ]
   },
   {
-    name: 'Yessenia Flores',
-    role: 'Mentora de liderazgo juvenil',
-    bio: 'Facilitadora intercultural que acompaña a jóvenes afrodescendientes en procesos de liderazgo, economía solidaria y autocuidado.',
-    focus: 'Coordina círculos de escucha, residencias creativas y acompañamiento psicosocial.',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/15.jpeg',
-    layout: 'md:col-span-3 md:row-span-2'
+    name: 'Elizabeth Méndez Grueso',
+    role: 'Socia fundadora',
+    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/funtecoElizabeth.png',
+    shortBio:
+      'Economista popular que acompaña emprendimientos liderados por mujeres afro en Quito y Esmeraldas con enfoque solidario.',
+    bio: 'Elizabeth articula procesos de economía feminista afro, fortaleciendo cooperativas, fondos solidarios y redes de comercialización justa. Diseña herramientas financieras accesibles y procesos de capacitación que priorizan el bienestar colectivo.',
+    focus: 'Fortalece economías del cuidado y emprendimientos afro.',
+    socials: [
+      {
+        platform: 'instagram',
+        label: 'Instagram de Elizabeth Méndez Grueso',
+        url: 'https://www.instagram.com/'
+      },
+      {
+        platform: 'facebook',
+        label: 'Facebook de Elizabeth Méndez Grueso',
+        url: 'https://www.facebook.com/'
+      }
+    ]
   },
   {
-    name: 'Red de voluntarias tejedoras',
-    role: 'Equipos territoriales',
-    bio: 'Más de 40 mujeres sostienen talleres, campañas de sensibilización y ferias comunitarias desde Esmeraldas hasta Loja.',
-    focus: 'Fortalecen la economía del cuidado y activan respuestas rápidas ante emergencias.',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/14.jpg',
-    layout: 'md:col-span-3'
+    name: 'Francia Jenny Moreno',
+    role: 'Coordinadora de proyectos',
+    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/funtecoFrancia.png',
+    shortBio:
+      'Ingeniera en desarrollo local con experiencia en gestión de fondos y programas con enfoque interseccional en Ecuador.',
+    bio: 'Francia coordina proyectos de justicia racial y movilidad humana, liderando equipos territoriales y procesos de evaluación participativa. Gestiona alianzas institucionales y garantiza que cada iniciativa centre el cuidado y la sostenibilidad.',
+    focus: 'Gestiona proyectos con enfoque interseccional y territorial.',
+    socials: [
+      {
+        platform: 'linkedin',
+        label: 'LinkedIn de Francia Jenny Moreno',
+        url: 'https://www.linkedin.com/'
+      },
+      {
+        platform: 'web',
+        label: 'Portafolio de Francia Jenny Moreno',
+        url: 'https://example.com/'
+      }
+    ]
   }
 ];

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import TeamGrid from '../components/TeamGrid.astro';
 import { teamMembers } from '../data/team';
 ---
 <BaseLayout title="Nosotras" description="Conoce al equipo feminista afro de Funteco que teje investigación, educación y cuidado comunitario en Ecuador.">
@@ -59,31 +60,7 @@ import { teamMembers } from '../data/team';
             Cada integrante conecta saberes ancestrales con innovación social para acompañar a mujeres, juventudes y familias afro en Ecuador. Te presentamos a quienes impulsan los programas y alianzas de Funteco.
           </p>
         </div>
-        <div class="grid gap-6 md:grid-cols-6 auto-rows-[minmax(220px,_auto)]">
-          {teamMembers.map((member, index) => (
-            <article
-              class={`group relative overflow-hidden rounded-3xl border border-accent-blush/40 bg-white/90 shadow-lg ${member.layout}`}
-            >
-              <img
-                src={member.image}
-                alt={`Retrato de ${member.name}`}
-                class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                loading={index === 0 ? 'eager' : 'lazy'}
-              />
-              <div class="absolute inset-0 bg-gradient-to-t from-primary-dark/80 via-primary-dark/40 to-transparent"></div>
-              <div class="absolute inset-x-0 bottom-0 space-y-3 p-6 text-white">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.2em] text-accent/80">{member.role}</p>
-                  <h3 class="text-2xl font-semibold leading-snug">{member.name}</h3>
-                </div>
-                <p class="text-sm text-white/80 leading-relaxed">{member.bio}</p>
-                <div class="rounded-2xl bg-white/10 p-3 text-xs font-medium text-white/90 backdrop-blur">
-                  {member.focus}
-                </div>
-              </div>
-            </article>
-          ))}
-        </div>
+        <TeamGrid members={teamMembers} />
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the team data with the four requested integrantes and extend the schema with social links and bios
- add a reusable TeamGrid component that displays the members and opens a modal with biography and social links
- update the Nosotras page to use the new interactive grid layout

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ddfe1c5bc083238b6c2bb693b5648e