### PR TITLE
Add hidden admin dashboard with role-based content controls

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,0 +1,34 @@
+---
+const { title = "Panel de administración" } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="es" class="bg-slate-950">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title} | FunTeco</title>
+    <meta
+      name="description"
+      content="Zona privada para la administración de contenidos de FunTeco"
+    />
+  </head>
+  <body class="bg-slate-950 text-slate-100 min-h-screen">
+    <div class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-10">
+      <header class="mb-8 border-b border-slate-800 pb-6">
+        <h1 class="text-3xl font-semibold tracking-tight text-teal-300">
+          {title}
+        </h1>
+        <p class="mt-2 text-sm text-slate-400">
+          Solo visible para el equipo autorizado. Utiliza tus credenciales
+          internas para gestionar la web.
+        </p>
+      </header>
+      <main class="flex-1">
+        <slot />
+      </main>
+      <footer class="mt-10 border-t border-slate-800 pt-6 text-xs text-slate-600">
+        FunTeco · Módulo privado de administración
+      </footer>
+    </div>
+  </body>
+</html>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,198 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { ROLES } from "../../utils/adminStore";
+import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
+---
+<AdminLayout title="Centro de control">
+  <div
+    id="admin-app"
+    class="grid gap-10 rounded-2xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40"
+  >
+    <section id="login-view" class="mx-auto w-full max-w-md">
+      <h2 class="text-xl font-semibold text-teal-200">Acceso privado</h2>
+      <p class="mt-1 text-sm text-slate-400">
+        Introduce tus credenciales para acceder al gestor de contenidos.
+      </p>
+      <form id="login-form" class="mt-6 space-y-4">
+        <label class="block text-sm">
+          <span class="mb-1 block font-medium text-slate-300">Usuario</span>
+          <input
+            name="username"
+            type="text"
+            required
+            autocomplete="username"
+            class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+          />
+        </label>
+        <label class="block text-sm">
+          <span class="mb-1 block font-medium text-slate-300">Contraseña</span>
+          <input
+            name="password"
+            type="password"
+            required
+            autocomplete="current-password"
+            class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+          />
+        </label>
+        <button
+          type="submit"
+          class="w-full rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+        >
+          Entrar
+        </button>
+      </form>
+      <p
+        id="login-error"
+        class="mt-4 hidden rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
+      ></p>
+    </section>
+
+    <section id="dashboard" class="hidden space-y-10">
+      <div class="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-900/60 p-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-xl font-semibold text-teal-200">
+            Bienvenido, <span id="current-user"></span>
+          </h2>
+          <p class="text-sm text-slate-400">
+            Gestiona el contenido y los usuarios según tus permisos.
+          </p>
+        </div>
+        <button
+          id="logout-btn"
+          class="self-start rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-rose-500 hover:text-rose-300"
+        >
+          Cerrar sesión
+        </button>
+      </div>
+
+      <div class="grid gap-8 lg:grid-cols-2">
+        <section
+          aria-labelledby="content-manager"
+          class="space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
+        >
+          <div>
+            <h3 id="content-manager" class="text-lg font-semibold text-teal-200">
+              Gestor de contenidos
+            </h3>
+            <p class="mt-1 text-sm text-slate-400">
+              Crea, edita y publica secciones sin afectar el diseño del sitio.
+            </p>
+          </div>
+
+          <form id="section-form" class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+            <input type="hidden" name="sectionId" />
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Título</span>
+              <input
+                name="title"
+                type="text"
+                required
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Contenido</span>
+              <textarea
+                name="content"
+                required
+                rows="4"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              ></textarea>
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Estado</span>
+              <select
+                name="status"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              >
+                <option value="draft">Borrador</option>
+                <option value="published">Publicado</option>
+              </select>
+            </label>
+            <div class="flex items-center gap-3">
+              <button
+                type="submit"
+                class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+              >
+                Guardar sección
+              </button>
+              <button
+                type="button"
+                id="cancel-edit"
+                class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
+              >
+                Cancelar edición
+              </button>
+            </div>
+            <p
+              id="section-feedback"
+              class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+            ></p>
+          </form>
+
+          <ul id="section-list" class="space-y-3 text-sm text-slate-200"></ul>
+        </section>
+
+        <section
+          id="user-management"
+          class="hidden space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
+          aria-labelledby="user-manager"
+        >
+          <div>
+            <h3 id="user-manager" class="text-lg font-semibold text-teal-200">
+              Gestión de usuarios y roles
+            </h3>
+            <p class="mt-1 text-sm text-slate-400">
+              Controla quién puede administrar contenidos o gestionar permisos.
+            </p>
+          </div>
+
+          <form id="user-form" class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Usuario</span>
+              <input
+                name="username"
+                required
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Contraseña</span>
+              <input
+                name="password"
+                type="password"
+                required
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Rol</span>
+              <select
+                name="role"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              >
+                {ROLES.map((role) => (
+                  <option value={role}>{role}</option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="submit"
+              class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+            >
+              Crear usuario
+            </button>
+            <p
+              id="user-feedback"
+              class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+            ></p>
+          </form>
+
+          <ul id="user-list" class="space-y-3 text-sm text-slate-200"></ul>
+        </section>
+      </div>
+    </section>
+  </div>
+</AdminLayout>
+
+<script type="module" src={adminDashboardScript}></script>

--- a/src/scripts/adminDashboard.ts
+++ b/src/scripts/adminDashboard.ts
@@ -1,0 +1,281 @@
+import { createAdminStore, ROLES } from "../utils/adminStore";
+
+const root = document.querySelector<HTMLElement>("#admin-app");
+if (!root) {
+  console.warn("Vista de administración no encontrada");
+} else {
+  const store = createAdminStore(window.localStorage);
+  const loginView = document.querySelector<HTMLElement>("#login-view");
+  const dashboard = document.querySelector<HTMLElement>("#dashboard");
+  const loginForm = document.querySelector<HTMLFormElement>("#login-form");
+  const loginError = document.querySelector<HTMLElement>("#login-error");
+  const currentUser = document.querySelector<HTMLElement>("#current-user");
+  const logoutBtn = document.querySelector<HTMLButtonElement>("#logout-btn");
+  const sectionForm = document.querySelector<HTMLFormElement>("#section-form");
+  const sectionList = document.querySelector<HTMLElement>("#section-list");
+  const sectionFeedback = document.querySelector<HTMLElement>("#section-feedback");
+  const cancelEditBtn = document.querySelector<HTMLButtonElement>("#cancel-edit");
+  const userManagement = document.querySelector<HTMLElement>("#user-management");
+  const userForm = document.querySelector<HTMLFormElement>("#user-form");
+  const userList = document.querySelector<HTMLElement>("#user-list");
+  const userFeedback = document.querySelector<HTMLElement>("#user-feedback");
+
+  const setHidden = (element: Element | null, hidden: boolean) => {
+    if (!element) return;
+    element.classList.toggle("hidden", hidden);
+  };
+
+  const setMessage = (
+    element: HTMLElement | null,
+    message: string,
+    type: "info" | "error" | "success" = "info"
+  ) => {
+    if (!element) return;
+    if (!message) {
+      element.classList.add("hidden");
+      element.textContent = "";
+      return;
+    }
+    element.textContent = message;
+    element.classList.remove("hidden");
+    element.classList.toggle("border-rose-500/40", type === "error");
+    element.classList.toggle("text-rose-200", type === "error");
+    element.classList.toggle("border-teal-500/40", type === "success");
+    element.classList.toggle("text-teal-200", type === "success");
+    if (type === "info") {
+      element.classList.remove("border-rose-500/40", "border-teal-500/40");
+      element.classList.remove("text-rose-200", "text-teal-200");
+    }
+  };
+
+  const render = () => {
+    const state = store.getState();
+    const activeUser = state.users.find((user) => user.id === state.currentUserId) ?? null;
+    const isAuthenticated = Boolean(activeUser);
+
+    setHidden(loginView, isAuthenticated);
+    setHidden(dashboard, !isAuthenticated);
+    if (!isAuthenticated) {
+      loginForm?.reset();
+      setMessage(loginError, "", "info");
+      return;
+    }
+
+    if (currentUser && activeUser) {
+      currentUser.textContent = `${activeUser.username} · ${activeUser.role}`;
+    }
+
+    const canManageUsers = store.canManageUsers();
+    setHidden(userManagement, !canManageUsers);
+
+    if (sectionList) {
+      sectionList.innerHTML = "";
+      state.sections
+        .slice()
+        .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+        .forEach((section) => {
+          const item = document.createElement("li");
+          item.className =
+            "rounded-lg border border-slate-800 bg-slate-950/40 p-4 shadow-inner shadow-slate-950/30";
+          item.innerHTML = `
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h4 class="font-semibold text-teal-200">${section.title}</h4>
+                <p class="mt-1 text-xs uppercase tracking-wide text-slate-500">${
+                  section.status === "published" ? "Publicado" : "Borrador"
+                }</p>
+                <p class="mt-2 text-xs text-slate-500">Última actualización: ${new Date(
+                  section.updatedAt
+                ).toLocaleString()}</p>
+              </div>
+              <div class="flex flex-col gap-2">
+                <button
+                  data-action="edit"
+                  data-id="${section.id}"
+                  class="rounded bg-slate-800 px-3 py-1 text-xs font-medium text-slate-200 transition hover:bg-slate-700"
+                >
+                  Editar
+                </button>
+                <button
+                  data-action="delete"
+                  data-id="${section.id}"
+                  class="rounded bg-rose-600/80 px-3 py-1 text-xs font-medium text-rose-100 transition hover:bg-rose-600"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </div>
+            <p class="mt-3 text-sm text-slate-300">${section.content}</p>
+          `;
+          sectionList.appendChild(item);
+        });
+    }
+
+    if (userList && canManageUsers) {
+      userList.innerHTML = "";
+      state.users
+        .slice()
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .forEach((user) => {
+          const item = document.createElement("li");
+          item.className =
+            "flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/40 p-4";
+          item.innerHTML = `
+            <div>
+              <p class="font-semibold text-slate-100">${user.username}</p>
+              <p class="text-xs uppercase tracking-wide text-slate-500">${user.role}</p>
+            </div>
+            <button
+              data-action="remove-user"
+              data-id="${user.id}"
+              class="rounded bg-rose-600/80 px-3 py-1 text-xs font-semibold text-rose-100 transition hover:bg-rose-600"
+            >
+              Eliminar
+            </button>
+          `;
+          userList.appendChild(item);
+        });
+    }
+  };
+
+  loginForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    const username = String(formData.get("username") ?? "").trim();
+    const password = String(formData.get("password") ?? "").trim();
+    try {
+      store.login(username, password);
+      setMessage(loginError, "", "info");
+    } catch (error) {
+      setMessage(
+        loginError,
+        error instanceof Error ? error.message : "No fue posible iniciar sesión",
+        "error"
+      );
+    }
+    render();
+  });
+
+  logoutBtn?.addEventListener("click", () => {
+    store.logout();
+    sectionForm?.reset();
+    userForm?.reset();
+    render();
+  });
+
+  sectionForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(sectionForm);
+    const sectionId = String(formData.get("sectionId") ?? "");
+    const payload = {
+      title: String(formData.get("title") ?? "").trim(),
+      content: String(formData.get("content") ?? "").trim(),
+      status: String(formData.get("status") ?? "draft") as "draft" | "published",
+    };
+    try {
+      if (sectionId) {
+        store.updateSection(sectionId, payload);
+        setMessage(sectionFeedback, "Sección actualizada correctamente", "success");
+      } else {
+        store.createSection(payload);
+        setMessage(sectionFeedback, "Sección creada correctamente", "success");
+      }
+      sectionForm.reset();
+      cancelEditBtn?.classList.add("hidden");
+    } catch (error) {
+      setMessage(
+        sectionFeedback,
+        error instanceof Error ? error.message : "No fue posible guardar",
+        "error"
+      );
+    }
+    render();
+  });
+
+  cancelEditBtn?.addEventListener("click", () => {
+    sectionForm?.reset();
+    cancelEditBtn.classList.add("hidden");
+    setMessage(sectionFeedback, "Edición cancelada", "info");
+  });
+
+  sectionList?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const action = target.dataset.action;
+    const id = target.dataset.id;
+    if (!id) return;
+    if (action === "edit") {
+      const state = store.getState();
+      const section = state.sections.find((item) => item.id === id);
+      if (!section || !sectionForm) return;
+      const idField = sectionForm.querySelector<HTMLInputElement>("[name=sectionId]");
+      const titleField = sectionForm.querySelector<HTMLInputElement>("[name=title]");
+      const contentField = sectionForm.querySelector<HTMLTextAreaElement>("[name=content]");
+      const statusField = sectionForm.querySelector<HTMLSelectElement>("[name=status]");
+      if (idField) idField.value = section.id;
+      if (titleField) titleField.value = section.title;
+      if (contentField) contentField.value = section.content;
+      if (statusField) statusField.value = section.status;
+      cancelEditBtn?.classList.remove("hidden");
+      setMessage(sectionFeedback, "Editando sección seleccionada", "info");
+    }
+    if (action === "delete") {
+      try {
+        store.deleteSection(id);
+        setMessage(sectionFeedback, "Sección eliminada", "success");
+      } catch (error) {
+        setMessage(
+          sectionFeedback,
+          error instanceof Error ? error.message : "Sin permisos para eliminar",
+          "error"
+        );
+      }
+      render();
+    }
+  });
+
+  userForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(userForm);
+    const payload = {
+      username: String(formData.get("username") ?? "").trim(),
+      password: String(formData.get("password") ?? "").trim(),
+      role: String(formData.get("role") ?? ROLES[0]),
+    };
+    try {
+      store.createUser(payload);
+      userForm.reset();
+      setMessage(userFeedback, "Usuario creado", "success");
+    } catch (error) {
+      setMessage(
+        userFeedback,
+        error instanceof Error ? error.message : "No fue posible crear el usuario",
+        "error"
+      );
+    }
+    render();
+  });
+
+  userList?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const action = target.dataset.action;
+    const id = target.dataset.id;
+    if (action === "remove-user" && id) {
+      try {
+        store.deleteUser(id);
+        setMessage(userFeedback, "Usuario eliminado", "success");
+      } catch (error) {
+        setMessage(
+          userFeedback,
+          error instanceof Error ? error.message : "No fue posible eliminar",
+          "error"
+        );
+      }
+      render();
+    }
+  });
+
+  store.subscribe(render);
+  render();
+}

--- a/src/tests/adminStore.test.ts
+++ b/src/tests/adminStore.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { createAdminStore } from "../utils/adminStore";
+
+function createStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+  };
+}
+
+describe("adminStore", () => {
+  const setup = () => {
+    const storage = createStorage();
+    const store = createAdminStore(storage);
+    return { store, storage };
+  };
+
+  it("permite iniciar sesión con credenciales válidas", () => {
+    const { store } = setup();
+    const user = store.login("admin", "admin123");
+    expect(user.username).toBe("admin");
+    expect(store.getState().currentUserId).toBe(user.id);
+  });
+
+  it("lanza error con credenciales incorrectas", () => {
+    const { store } = setup();
+    expect(() => store.login("admin", "wrong"))
+      .toThrowError(/Credenciales inválidas/);
+  });
+
+  it("permite al administrador crear y eliminar usuarios", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    const newUser = store.createUser({
+      username: "editor-test",
+      password: "secret",
+      role: "Editor",
+    });
+    expect(newUser.role).toBe("Editor");
+    expect(store.getState().users.some((user) => user.id === newUser.id)).toBe(
+      true
+    );
+
+    store.deleteUser(newUser.id);
+    expect(store.getState().users.some((user) => user.id === newUser.id)).toBe(
+      false
+    );
+  });
+
+  it("impide a un editor gestionar usuarios", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    store.createUser({ username: "solo-editor", password: "secret", role: "Editor" });
+    store.logout();
+    store.login("solo-editor", "secret");
+    expect(store.canManageUsers()).toBe(false);
+    expect(() =>
+      store.createUser({ username: "otro", password: "123", role: "Autor" })
+    ).toThrowError(/Sin permisos/);
+  });
+
+  it("controla las publicaciones de un colaborador", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    store.createUser({ username: "colab", password: "secret", role: "Colaborador" });
+    store.logout();
+    store.login("colab", "secret");
+    const section = store.createSection({
+      title: "Borrador colaborador",
+      content: "Contenido de prueba",
+      status: "published",
+    });
+    expect(section.status).toBe("draft");
+    expect(() =>
+      store.updateSection(section.id, { status: "published" })
+    ).toThrowError(/Sin permisos/);
+  });
+
+  it("evita que un autor edite secciones ajenas", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    store.createUser({ username: "autor", password: "secret", role: "Autor" });
+    const foreignSection = store.createSection({
+      title: "Sección admin",
+      content: "Contenido",
+      status: "published",
+    });
+    store.logout();
+    store.login("autor", "secret");
+    const ownSection = store.createSection({
+      title: "Sección propia",
+      content: "Contenido del autor",
+      status: "draft",
+    });
+    expect(ownSection.ownerId).not.toBe(foreignSection.ownerId);
+    expect(() =>
+      store.updateSection(foreignSection.id, { title: "Hack" })
+    ).toThrowError(/Sin permisos/);
+  });
+
+  it("impide que un moderador elimine secciones", () => {
+    const { store } = setup();
+    store.login("moderador", "mod123");
+    const state = store.getState();
+    const target = state.sections[0];
+    expect(() => store.deleteSection(target.id)).toThrowError(/Sin permisos/);
+  });
+
+  it("permite a un editor eliminar secciones", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    store.createUser({ username: "editor", password: "secret", role: "Editor" });
+    const section = store.createSection({
+      title: "Sección a eliminar",
+      content: "Contenido",
+      status: "published",
+    });
+    store.logout();
+    store.login("editor", "secret");
+    expect(() => store.deleteSection(section.id)).not.toThrow();
+    expect(store.getState().sections.some((item) => item.id === section.id)).toBe(
+      false
+    );
+  });
+
+  it("persiste los datos en el almacenamiento proporcionado", () => {
+    const storage = createStorage();
+    const storeA = createAdminStore(storage);
+    storeA.login("admin", "admin123");
+    storeA.createUser({ username: "persistente", password: "secret", role: "Autor" });
+    const section = storeA.createSection({
+      title: "Sección persistente",
+      content: "Contenido",
+      status: "draft",
+    });
+
+    const storeB = createAdminStore(storage);
+    const state = storeB.getState();
+    expect(state.users.some((user) => user.username === "persistente")).toBe(
+      true
+    );
+    expect(state.sections.some((item) => item.id === section.id)).toBe(true);
+  });
+});

--- a/src/utils/adminStore.ts
+++ b/src/utils/adminStore.ts
@@ -1,0 +1,425 @@
+export type Role =
+  | "Administrador"
+  | "Editor"
+  | "Autor"
+  | "Colaborador"
+  | "Moderador";
+
+export type SectionStatus = "draft" | "published";
+
+export interface User {
+  id: string;
+  username: string;
+  password: string;
+  role: Role;
+  createdAt: string;
+}
+
+export interface Section {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  status: SectionStatus;
+  ownerId: string;
+  updatedAt: string;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+const STORAGE_KEY = "funteco-admin-state";
+
+const ROLE_CAPABILITIES: Record<
+  Role,
+  {
+    manageUsers: boolean;
+    createSections: boolean;
+    editAnySection: boolean;
+    deleteAnySection: boolean;
+    publish: boolean;
+  }
+> = {
+  Administrador: {
+    manageUsers: true,
+    createSections: true,
+    editAnySection: true,
+    deleteAnySection: true,
+    publish: true,
+  },
+  Editor: {
+    manageUsers: false,
+    createSections: true,
+    editAnySection: true,
+    deleteAnySection: true,
+    publish: true,
+  },
+  Autor: {
+    manageUsers: false,
+    createSections: true,
+    editAnySection: false,
+    deleteAnySection: false,
+    publish: true,
+  },
+  Colaborador: {
+    manageUsers: false,
+    createSections: true,
+    editAnySection: false,
+    deleteAnySection: false,
+    publish: false,
+  },
+  Moderador: {
+    manageUsers: true,
+    createSections: false,
+    editAnySection: true,
+    deleteAnySection: false,
+    publish: true,
+  },
+};
+
+interface AdminState {
+  users: User[];
+  sections: Section[];
+  currentUserId: string | null;
+}
+
+const memoryStorage = (): StorageLike => {
+  const store = new Map<string, string>();
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key, value) {
+      store.set(key, value);
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+  };
+};
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+
+const createId = () => {
+  const random = Math.random().toString(36).slice(2, 10);
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return random;
+};
+
+const initialUsers: User[] = [
+  {
+    id: "user-admin",
+    username: "admin",
+    password: "admin123",
+    role: "Administrador",
+    createdAt: new Date("2023-01-01").toISOString(),
+  },
+  {
+    id: "user-moderator",
+    username: "moderador",
+    password: "mod123",
+    role: "Moderador",
+    createdAt: new Date("2023-01-05").toISOString(),
+  },
+];
+
+const initialSections: Section[] = [
+  {
+    id: "section-1",
+    title: "Bienvenida",
+    slug: "bienvenida",
+    content:
+      "Mensaje de bienvenida editable desde el módulo de administración.",
+    status: "published",
+    ownerId: "user-admin",
+    updatedAt: new Date("2023-02-01").toISOString(),
+  },
+  {
+    id: "section-2",
+    title: "Próximos eventos",
+    slug: "proximos-eventos",
+    content: "Listado de eventos futuros gestionable por el equipo.",
+    status: "draft",
+    ownerId: "user-admin",
+    updatedAt: new Date("2023-02-10").toISOString(),
+  },
+];
+
+const defaultState: AdminState = {
+  users: initialUsers,
+  sections: initialSections,
+  currentUserId: null,
+};
+
+export const ROLES: Role[] = [
+  "Administrador",
+  "Editor",
+  "Autor",
+  "Colaborador",
+  "Moderador",
+];
+
+const ensure = (condition: boolean, message: string) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+export interface AdminStore {
+  getState(): AdminState;
+  subscribe(listener: () => void): () => void;
+  login(username: string, password: string): User;
+  logout(): void;
+  canManageUsers(): boolean;
+  canPublish(): boolean;
+  createUser(data: Omit<User, "id" | "createdAt"> & { password: string }): User;
+  updateUser(
+    id: string,
+    updates: Partial<Pick<User, "password" | "role">>
+  ): User;
+  deleteUser(id: string): void;
+  createSection(data: {
+    title: string;
+    content: string;
+    status: SectionStatus;
+  }): Section;
+  updateSection(
+    id: string,
+    updates: Partial<Pick<Section, "title" | "content" | "status">>
+  ): Section;
+  deleteSection(id: string): void;
+}
+
+const getCapabilities = (user: User | null) =>
+  user ? ROLE_CAPABILITIES[user.role] : null;
+
+const canEditSection = (
+  user: User | null,
+  section: Section,
+  capabilities: ReturnType<typeof getCapabilities>
+) => {
+  if (!user || !capabilities) return false;
+  if (capabilities.editAnySection) return true;
+  return section.ownerId === user.id;
+};
+
+const canDeleteSection = (
+  user: User | null,
+  section: Section,
+  capabilities: ReturnType<typeof getCapabilities>
+) => {
+  if (!user || !capabilities) return false;
+  if (capabilities.deleteAnySection) return true;
+  return section.ownerId === user.id;
+};
+
+export const createAdminStore = (
+  storage: StorageLike = memoryStorage()
+): AdminStore => {
+  let state: AdminState = loadState(storage);
+  const listeners = new Set<() => void>();
+
+  function loadState(storage: StorageLike) {
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      if (!raw) return clone(defaultState);
+      const parsed = JSON.parse(raw);
+      return {
+        ...clone(defaultState),
+        ...parsed,
+        users: parsed.users ?? clone(defaultState.users),
+        sections: parsed.sections ?? clone(defaultState.sections),
+        currentUserId:
+          typeof parsed.currentUserId === "string"
+            ? parsed.currentUserId
+            : null,
+      } satisfies AdminState;
+    } catch (error) {
+      console.warn("No se pudo cargar el estado del administrador", error);
+      return clone(defaultState);
+    }
+  }
+
+  function persist() {
+    storage.setItem(STORAGE_KEY, JSON.stringify(state));
+    listeners.forEach((listener) => listener());
+  }
+
+  function getCurrentUser(): User | null {
+    return state.users.find((user) => user.id === state.currentUserId) ?? null;
+  }
+
+  return {
+    getState() {
+      return clone(state);
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    login(username, password) {
+      const user = state.users.find(
+        (candidate) =>
+          candidate.username === username && candidate.password === password
+      );
+      ensure(!!user, "Credenciales inválidas");
+      state.currentUserId = user!.id;
+      persist();
+      return clone(user!);
+    },
+    logout() {
+      state.currentUserId = null;
+      persist();
+    },
+    canManageUsers() {
+      const user = getCurrentUser();
+      const capabilities = getCapabilities(user);
+      return Boolean(capabilities?.manageUsers);
+    },
+    canPublish() {
+      const user = getCurrentUser();
+      const capabilities = getCapabilities(user);
+      return Boolean(capabilities?.publish);
+    },
+    createUser(data) {
+      const currentUser = getCurrentUser();
+      const capabilities = getCapabilities(currentUser);
+      ensure(!!capabilities?.manageUsers, "Sin permisos para crear usuarios");
+      ensure(
+        ROLES.includes(data.role),
+        "El rol especificado no es válido"
+      );
+      ensure(
+        !state.users.some((user) => user.username === data.username),
+        "El nombre de usuario ya existe"
+      );
+
+      const newUser: User = {
+        id: `user-${createId()}`,
+        username: data.username,
+        password: data.password,
+        role: data.role,
+        createdAt: new Date().toISOString(),
+      };
+      state.users = [...state.users, newUser];
+      persist();
+      return clone(newUser);
+    },
+    updateUser(id, updates) {
+      const currentUser = getCurrentUser();
+      const capabilities = getCapabilities(currentUser);
+      ensure(!!capabilities?.manageUsers, "Sin permisos para editar usuarios");
+      const userIndex = state.users.findIndex((user) => user.id === id);
+      ensure(userIndex >= 0, "Usuario no encontrado");
+      const updated: User = {
+        ...state.users[userIndex],
+        ...updates,
+      };
+      state.users[userIndex] = updated;
+      persist();
+      return clone(updated);
+    },
+    deleteUser(id) {
+      const currentUser = getCurrentUser();
+      const capabilities = getCapabilities(currentUser);
+      ensure(!!capabilities?.manageUsers, "Sin permisos para eliminar usuarios");
+      ensure(state.currentUserId !== id, "No puedes eliminar tu propio usuario");
+      const before = state.users.length;
+      state.users = state.users.filter((user) => user.id !== id);
+      ensure(state.users.length !== before, "Usuario no encontrado");
+      state.sections = state.sections.map((section) =>
+        section.ownerId === id ? { ...section, ownerId: currentUser!.id } : section
+      );
+      persist();
+    },
+    createSection(data) {
+      const currentUser = getCurrentUser();
+      ensure(!!currentUser, "Debes iniciar sesión para crear secciones");
+      const capabilities = getCapabilities(currentUser);
+      ensure(
+        !!capabilities?.createSections,
+        "Sin permisos para crear secciones"
+      );
+      const status: SectionStatus = capabilities.publish
+        ? data.status
+        : "draft";
+      if (!capabilities.publish && data.status === "published") {
+        console.warn(
+          "El rol actual no puede publicar directamente, se guardará como borrador"
+        );
+      }
+      const now = new Date().toISOString();
+      const section: Section = {
+        id: `section-${createId()}`,
+        title: data.title,
+        slug: slugify(data.title),
+        content: data.content,
+        status,
+        ownerId: currentUser.id,
+        updatedAt: now,
+      };
+      state.sections = [section, ...state.sections];
+      persist();
+      return clone(section);
+    },
+    updateSection(id, updates) {
+      const currentUser = getCurrentUser();
+      ensure(!!currentUser, "Debes iniciar sesión para editar secciones");
+      const sectionIndex = state.sections.findIndex((section) => section.id === id);
+      ensure(sectionIndex >= 0, "Sección no encontrada");
+      const section = state.sections[sectionIndex];
+      const capabilities = getCapabilities(currentUser);
+      ensure(
+        canEditSection(currentUser, section, capabilities),
+        "Sin permisos para editar esta sección"
+      );
+      if (updates.status === "published" && !capabilities?.publish) {
+        ensure(false, "Sin permisos para publicar esta sección");
+      }
+      const newStatus = updates.status ?? section.status;
+      ensure(
+        newStatus === "draft" || newStatus === "published",
+        "Estado de sección no válido"
+      );
+      const updated: Section = {
+        ...section,
+        ...updates,
+        status: newStatus,
+        slug: updates.title ? slugify(updates.title) : section.slug,
+        updatedAt: new Date().toISOString(),
+      };
+      state.sections[sectionIndex] = updated;
+      persist();
+      return clone(updated);
+    },
+    deleteSection(id) {
+      const currentUser = getCurrentUser();
+      ensure(!!currentUser, "Debes iniciar sesión para eliminar secciones");
+      const section = state.sections.find((item) => item.id === id);
+      ensure(!!section, "Sección no encontrada");
+      const capabilities = getCapabilities(currentUser);
+      ensure(
+        canDeleteSection(currentUser, section!, capabilities),
+        "Sin permisos para eliminar esta sección"
+      );
+      state.sections = state.sections.filter((item) => item.id !== id);
+      persist();
+    },
+  };
+};
+
+export type { AdminState };


### PR DESCRIPTION
## Summary
- add a private admin layout and `/admin` page with login, content manager, and user management UI
- implement a reusable adminStore with role-based permissions and section CRUD helpers
- add client script wiring the dashboard UI to the store and comprehensive vitest coverage for roles and persistence

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68de0e541d2483239b3ebf9be7b902d0