### PR TITLE
Integrate Strapi-style admin modules and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ funteco_astro/
 
 ## Requisitos
 
-Para ejecutar este proyecto necesitas tener instalado **Node.js** (versión 18 o superior) y **npm**. Si planeas realizar pruebas, también se recomienda instalar `vitest` globalmente o ejecutarlo mediante los scripts.
+Para ejecutar este proyecto necesitas tener instalado **Node.js** (versión 18 o superior) y **pnpm**. Si planeas realizar pruebas, también se recomienda instalar `vitest` globalmente o ejecutarlo mediante los scripts.
 
 ## Instalación
 
@@ -51,7 +51,7 @@ Para ejecutar este proyecto necesitas tener instalado **Node.js** (versión 18 o
 2. Instala las dependencias:
 
    ```bash
-   npm install
+   pnpm install
    ```
 
    > **Nota:** Si no tienes acceso a internet en este entorno, revisa la sección de dependencias del `package.json` para asegurarte de que las versiones sean correctas. Puedes instalar paquetes locales o usar un registro privado.
@@ -60,10 +60,14 @@ Para ejecutar este proyecto necesitas tener instalado **Node.js** (versión 18 o
 
 Una vez instaladas las dependencias, puedes ejecutar los siguientes comandos:
 
-- `npm run dev` – Inicia el servidor de desarrollo en `http://localhost:3000` con recarga en caliente.
-- `npm run build` – Genera una versión estática optimizada en la carpeta `dist/` lista para desplegar en Vercel, Netlify u otro hosting estático.
-- `npm run preview` – Previsualiza el sitio de producción generado en `dist/`.
-- `npm run test` – Ejecuta las pruebas de Vitest definidas en `src/tests/design.test.js`.
+- `pnpm dev` – Inicia el servidor de desarrollo en `http://localhost:3000` con recarga en caliente.
+- `pnpm build` – Genera una versión estática optimizada en la carpeta `dist/` lista para desplegar en Vercel, Netlify u otro hosting estático.
+- `pnpm preview` – Previsualiza el sitio de producción generado en `dist/`.
+- `pnpm test` – Ejecuta la suite de Vitest, incluyendo las pruebas del módulo administrativo.
+
+## Documentación del panel administrativo
+
+En `docs/strapi-admin.md` encontrarás un resumen de los módulos inspirados en Strapi (Content-type Builder, Content Manager, Media Library y Users, Roles & Permissions), junto con detalles sobre personalización y pruebas.
 
 ## Buenas prácticas y próximos pasos
 

--- a/docs/strapi-admin.md
+++ b/docs/strapi-admin.md
@@ -1,0 +1,42 @@
+# Panel administrativo inspirado en Strapi
+
+Este proyecto incorpora un panel de administración basado en la filosofía de módulos de [Strapi](https://docs.strapi.io). El objetivo es ofrecer una experiencia similar a la consola oficial —con constructor de tipos de contenido, gestor de entradas, biblioteca de medios y control de usuarios— pero adaptada a las necesidades del MVP.
+
+## Módulos disponibles
+
+### Content-type Builder
+- Crea colecciones personalizadas indicando nombre visible, descripción, categoría e icono.
+- Añade o elimina campos compatibles con Strapi (`string`, `text`, `richtext`, `uid`, `media`, `enumeration`, `json`, `date`, `datetime`, `boolean`, `number`, `relation`).
+- Bloquea la eliminación de los tipos base (secciones, integrantes y eventos) para preservar la configuración esencial del sitio.
+
+### Content Manager
+- Gestiona las colecciones base y las personalizadas con estados `draft` y `published`.
+- Respeta las reglas de publicación por rol (por ejemplo, las personas colaboradoras solo pueden crear borradores).
+- Admite edición en línea, vista previa de estados y acciones de eliminación.
+
+### Media Library
+- Registra imágenes, documentos y otros recursos (se asume una URL pública).
+- Permite editar el texto alternativo y eliminar activos. Los recursos asociados a entradas se agregan automáticamente.
+
+### Users, Roles & Permissions
+- Administra cuentas internas, asigna los roles definidos y muestra sus capacidades según la matriz oficial de Strapi.
+- Restringe el acceso al módulo si la persona autenticada no posee permisos de gestión.
+
+## Flujo de autenticación
+1. Ingresar con las credenciales existentes (`admin`/`admin123`, `moderador`/`mod123`, etc.).
+2. Al iniciar sesión, el panel recuerda el usuario en `localStorage` para mantener la sesión.
+3. Cerrar sesión revierte la aplicación al modo de acceso protegido.
+
+## Personalización
+- Los nuevos tipos de contenido se almacenan en `localStorage` bajo la clave `funteco-strapi-modules` para facilitar prototipos sin backend.
+- Puedes extender los campos permitidos en `src/utils/strapiAdmin.ts` si necesitas componentes adicionales.
+- Las entradas de colecciones personalizadas admiten cualquier estructura basada en los campos configurados.
+
+## Pruebas unitarias
+Las pruebas de Vitest (`pnpm test`) validan:
+- Autenticación y permisos por rol.
+- Creación, actualización y eliminación de tipos de contenido y campos.
+- Gestión de entradas para colecciones base y personalizadas.
+- Operaciones de la biblioteca multimedia y persistencia en almacenamiento local.
+
+Para añadir nuevas validaciones, utiliza `createStrapiAdmin` y los módulos expuestos en `src/utils/strapiAdmin.ts` como harías con el SDK oficial de Strapi.

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -69,26 +69,26 @@ import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
         <button
           type="button"
           class="rounded-lg border border-teal-500/60 bg-teal-500/10 px-4 py-2 text-sm font-medium text-teal-200 transition hover:bg-teal-500/20"
-          data-view="content"
+          data-view="content-types"
           aria-pressed="true"
         >
-          Contenido
+          Content-type Builder
         </button>
         <button
           type="button"
           class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-teal-400 hover:text-teal-200"
-          data-view="team"
+          data-view="content-manager"
           aria-pressed="false"
         >
-          Equipo
+          Content Manager
         </button>
         <button
           type="button"
           class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-teal-400 hover:text-teal-200"
-          data-view="events"
+          data-view="media-library"
           aria-pressed="false"
         >
-          Eventos
+          Media Library
         </button>
         <button
           type="button"
@@ -97,259 +97,492 @@ import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
           aria-pressed="false"
           id="user-nav-btn"
         >
-          Gestión de usuarios y roles
+          Users, Roles & Permissions
         </button>
       </div>
 
       <div class="space-y-8">
         <section
-          aria-labelledby="content-manager"
+          aria-labelledby="content-type-builder"
           class="space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
-          data-view-panel="content"
+          data-view-panel="content-types"
+        >
+          <div>
+            <h3 id="content-type-builder" class="text-lg font-semibold text-teal-200">
+              Content-type Builder
+            </h3>
+            <p class="mt-1 text-sm text-slate-400">
+              Configura colecciones y campos personalizados siguiendo las pautas del panel de Strapi.
+            </p>
+          </div>
+
+          <form
+            id="content-type-form"
+            class="grid gap-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4 md:grid-cols-2"
+          >
+            <label class="block text-sm md:col-span-2">
+              <span class="mb-1 block font-medium text-slate-300">Nombre visible</span>
+              <input
+                name="displayName"
+                required
+                placeholder="Blog, Programas, Aliados…"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm md:col-span-2">
+              <span class="mb-1 block font-medium text-slate-300">Descripción</span>
+              <textarea
+                name="description"
+                rows="2"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                placeholder="Resume el propósito editorial del tipo de contenido"
+              ></textarea>
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Categoría</span>
+              <input
+                name="category"
+                placeholder="Colecciones personalizadas"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Icono</span>
+              <input
+                name="icon"
+                placeholder="database, calendar, book…"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-300 md:col-span-2">
+              <input
+                type="checkbox"
+                name="draftAndPublish"
+                checked
+                class="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-500 focus:ring-teal-500/40"
+              />
+              <span>Activar Draft &amp; Publish</span>
+            </label>
+            <div class="md:col-span-2 flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+              >
+                Crear tipo de contenido
+              </button>
+              <p
+                id="content-type-feedback"
+                class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+              ></p>
+            </div>
+          </form>
+
+          <form
+            id="content-field-form"
+            class="grid gap-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4 md:grid-cols-4"
+          >
+            <label class="block text-sm md:col-span-2">
+              <span class="mb-1 block font-medium text-slate-300">Tipo de contenido</span>
+              <select
+                name="uid"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              ></select>
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Nombre del campo</span>
+              <input
+                name="name"
+                required
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm">
+              <span class="mb-1 block font-medium text-slate-300">Tipo</span>
+              <select
+                name="type"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              >
+                <option value="string">Texto corto</option>
+                <option value="text">Texto largo</option>
+                <option value="richtext">Rich text</option>
+                <option value="uid">UID automático</option>
+                <option value="media">Media</option>
+                <option value="enumeration">Enumeración</option>
+                <option value="json">JSON</option>
+                <option value="date">Fecha</option>
+                <option value="datetime">Fecha y hora</option>
+                <option value="boolean">Booleano</option>
+                <option value="number">Número</option>
+                <option value="relation">Relación</option>
+              </select>
+            </label>
+            <label class="flex items-center gap-2 text-sm text-slate-300 md:col-span-2">
+              <input
+                type="checkbox"
+                name="required"
+                class="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-500 focus:ring-teal-500/40"
+              />
+              <span>Campo obligatorio</span>
+            </label>
+            <div class="md:col-span-4 flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+              >
+                Añadir campo
+              </button>
+              <p
+                id="content-field-feedback"
+                class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+              ></p>
+            </div>
+          </form>
+
+          <div class="space-y-4">
+            <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Colecciones configuradas
+            </h4>
+            <div id="content-type-list" class="space-y-4 text-sm text-slate-200"></div>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="content-manager"
+          class="hidden space-y-10 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
+          data-view-panel="content-manager"
         >
           <div>
             <h3 id="content-manager" class="text-lg font-semibold text-teal-200">
-              Gestor de contenidos
+              Content Manager
             </h3>
             <p class="mt-1 text-sm text-slate-400">
-              Crea, edita y publica secciones sin afectar el diseño del sitio.
+              Gestiona entradas para secciones, equipo y eventos con flujos de borradores y publicación.
             </p>
           </div>
 
-          <form id="section-form" class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
-            <input type="hidden" name="sectionId" />
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Título</span>
-              <input
-                name="title"
-                type="text"
-                required
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              />
-            </label>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Contenido</span>
-              <textarea
-                name="content"
-                required
-                rows="4"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              ></textarea>
-            </label>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Estado</span>
-              <select
-                name="status"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              >
-                <option value="draft">Borrador</option>
-                <option value="published">Publicado</option>
-              </select>
-            </label>
-            <div class="flex items-center gap-3">
-              <button
-                type="submit"
-                class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
-              >
-                Guardar sección
-              </button>
-              <button
-                type="button"
-                id="cancel-edit"
-                class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
-              >
-                Cancelar edición
-              </button>
-            </div>
-            <p
-              id="section-feedback"
-              class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
-            ></p>
-          </form>
-
-          <ul id="section-list" class="space-y-3 text-sm text-slate-200"></ul>
-        </section>
-
-        <section
-          class="hidden space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
-          aria-labelledby="team-manager"
-          data-view-panel="team"
-        >
-          <div>
-            <h3 id="team-manager" class="text-lg font-semibold text-teal-200">
-              Equipo FunTeco
-            </h3>
-            <p class="mt-1 text-sm text-slate-400">
-              Actualiza perfiles del equipo, guarda borradores y comparte la historia de cada integrante.
-            </p>
-          </div>
-
-          <form id="team-form" class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
-            <input type="hidden" name="memberId" />
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Nombre completo</span>
-                <input
-                  name="name"
-                  required
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Rol en el equipo</span>
-                <input
-                  name="role"
-                  required
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Imagen (URL)</span>
-                <input
-                  name="image"
-                  type="url"
-                  placeholder="https://..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Enfoque principal</span>
-                <input
-                  name="focus"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-            </div>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Biografía corta</span>
-              <textarea
-                name="shortBio"
-                rows="3"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              ></textarea>
-            </label>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Biografía extendida</span>
-              <textarea
-                name="bio"
-                rows="4"
-                placeholder="Escribe cada párrafo en una nueva línea"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              ></textarea>
-            </label>
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Áreas de experiencia</span>
-                <input
-                  name="expertise"
-                  placeholder="separa con comas"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Logros destacados</span>
-                <input
-                  name="highlights"
-                  placeholder="separa con comas"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-            </div>
-            <fieldset class="grid gap-4 rounded-lg border border-slate-800 p-4 md:grid-cols-2">
-              <legend class="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Redes sociales
-              </legend>
-              <label class="block text-xs">
-                <span class="mb-1 block font-medium text-slate-300">Instagram</span>
-                <input
-                  name="social-instagram"
-                  type="url"
-                  placeholder="https://instagram.com/..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-xs">
-                <span class="mb-1 block font-medium text-slate-300">Facebook</span>
-                <input
-                  name="social-facebook"
-                  type="url"
-                  placeholder="https://facebook.com/..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-xs">
-                <span class="mb-1 block font-medium text-slate-300">LinkedIn</span>
-                <input
-                  name="social-linkedin"
-                  type="url"
-                  placeholder="https://linkedin.com/in/..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-xs">
-                <span class="mb-1 block font-medium text-slate-300">Sitio web o portafolio</span>
-                <input
-                  name="social-web"
-                  type="url"
-                  placeholder="https://..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-            </fieldset>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Estado</span>
-              <select
-                name="status"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              >
-                <option value="draft">Borrador</option>
-                <option value="published">Publicado</option>
-              </select>
-            </label>
-            <div class="flex flex-wrap items-center gap-3">
-              <button
-                type="submit"
-                class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
-              >
-                Guardar integrante
-              </button>
-              <button
-                type="button"
-                id="cancel-team-edit"
-                class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
-              >
-                Cancelar edición
-              </button>
-            </div>
-            <p
-              id="team-feedback"
-              class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
-            ></p>
-          </form>
-
-          <div class="grid gap-6 lg:grid-cols-2">
-            <div class="space-y-3">
-              <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
-                Integrantes registrados
-              </h4>
-              <ul id="team-list" class="space-y-3 text-sm text-slate-200"></ul>
-            </div>
+          <div class="space-y-10">
             <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
               <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
-                Vista previa rápida
+                Secciones destacadas
               </h4>
-              <div class="space-y-3">
-                <div>
-                  <h5 class="text-xs font-semibold uppercase tracking-wide text-amber-300">
-                    Borradores
-                  </h5>
-                  <div id="team-preview-draft" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+              <form id="section-form" class="space-y-4">
+                <input type="hidden" name="sectionId" />
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Título</span>
+                  <input
+                    name="title"
+                    type="text"
+                    required
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  />
+                </label>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Contenido</span>
+                  <textarea
+                    name="content"
+                    required
+                    rows="4"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  ></textarea>
+                </label>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Estado</span>
+                  <select
+                    name="status"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  >
+                    <option value="draft">Borrador</option>
+                    <option value="published">Publicado</option>
+                  </select>
+                </label>
+                <div class="flex items-center gap-3">
+                  <button
+                    type="submit"
+                    class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+                  >
+                    Guardar sección
+                  </button>
+                  <button
+                    type="button"
+                    id="cancel-edit"
+                    class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
+                  >
+                    Cancelar edición
+                  </button>
                 </div>
-                <div>
-                  <h5 class="text-xs font-semibold uppercase tracking-wide text-emerald-300">
-                    Publicados
+                <p
+                  id="section-feedback"
+                  class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+                ></p>
+              </form>
+
+              <ul id="section-list" class="space-y-3 text-sm text-slate-200"></ul>
+            </div>
+
+            <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+              <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Equipo FunTeco
+              </h4>
+              <form id="team-form" class="space-y-4">
+                <input type="hidden" name="memberId" />
+                <div class="grid gap-4 md:grid-cols-2">
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Nombre completo</span>
+                    <input
+                      name="name"
+                      required
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Rol en el equipo</span>
+                    <input
+                      name="role"
+                      required
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                </div>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">URL de la imagen</span>
+                  <input
+                    name="image"
+                    required
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  />
+                </label>
+                <div class="grid gap-4 md:grid-cols-2">
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Extracto corto</span>
+                    <textarea
+                      name="shortBio"
+                      rows="3"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    ></textarea>
+                  </label>
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Área de enfoque</span>
+                    <input
+                      name="focus"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                </div>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Biografía (una línea por párrafo)</span>
+                  <textarea
+                    name="bio"
+                    rows="4"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  ></textarea>
+                </label>
+                <div class="grid gap-4 md:grid-cols-2">
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Experticias (separa con comas)</span>
+                    <input
+                      name="expertise"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Logros destacados (una línea por logro)</span>
+                    <textarea
+                      name="highlights"
+                      rows="3"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    ></textarea>
+                  </label>
+                </div>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Redes sociales (JSON)</span>
+                  <textarea
+                    name="socials"
+                    rows="3"
+                    placeholder='[{"platform":"instagram","label":"Instagram","url":"https://instagram.com"}]'
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  ></textarea>
+                </label>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Estado</span>
+                  <select
+                    name="status"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  >
+                    <option value="draft">Borrador</option>
+                    <option value="published">Publicado</option>
+                  </select>
+                </label>
+                <div class="flex flex-wrap items-center gap-3">
+                  <button
+                    type="submit"
+                    class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+                  >
+                    Guardar integrante
+                  </button>
+                  <button
+                    type="button"
+                    id="cancel-team-edit"
+                    class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
+                  >
+                    Cancelar edición
+                  </button>
+                </div>
+                <p
+                  id="team-feedback"
+                  class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+                ></p>
+              </form>
+
+              <div class="grid gap-6 lg:grid-cols-2">
+                <div class="space-y-3">
+                  <h5 class="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Perfiles activos
                   </h5>
-                  <div id="team-preview-published" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+                  <ul id="team-list" class="space-y-3 text-sm text-slate-200"></ul>
+                </div>
+                <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                  <h5 class="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Estado editorial
+                  </h5>
+                  <div class="space-y-3">
+                    <div>
+                      <p class="text-[11px] font-semibold uppercase tracking-wide text-amber-300">
+                        Borradores
+                      </p>
+                      <div id="team-preview-draft" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+                    </div>
+                    <div>
+                      <p class="text-[11px] font-semibold uppercase tracking-wide text-emerald-300">
+                        Publicados
+                      </p>
+                      <div id="team-preview-published" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+              <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                Agenda y eventos
+              </h4>
+              <form id="event-form" class="space-y-4">
+                <input type="hidden" name="eventId" />
+                <div class="grid gap-4 md:grid-cols-2">
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Título</span>
+                    <input
+                      name="title"
+                      required
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Fecha</span>
+                    <input
+                      name="date"
+                      type="date"
+                      required
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                </div>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Descripción breve</span>
+                  <textarea
+                    name="shortDescription"
+                    rows="3"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  ></textarea>
+                </label>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Descripción completa (una línea por párrafo)</span>
+                  <textarea
+                    name="description"
+                    rows="4"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  ></textarea>
+                </label>
+                <div class="grid gap-4 md:grid-cols-2">
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">Ubicación</span>
+                    <input
+                      name="location"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                  <label class="block text-sm">
+                    <span class="mb-1 block font-medium text-slate-300">URL de imagen</span>
+                    <input
+                      name="image"
+                      class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                    />
+                  </label>
+                </div>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Etiquetas</span>
+                  <input
+                    name="tags"
+                    placeholder="separa con comas"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  />
+                </label>
+                <label class="block text-sm">
+                  <span class="mb-1 block font-medium text-slate-300">Estado</span>
+                  <select
+                    name="status"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+                  >
+                    <option value="draft">Borrador</option>
+                    <option value="published">Publicado</option>
+                  </select>
+                </label>
+                <div class="flex flex-wrap items-center gap-3">
+                  <button
+                    type="submit"
+                    class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+                  >
+                    Guardar evento
+                  </button>
+                  <button
+                    type="button"
+                    id="cancel-event-edit"
+                    class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
+                  >
+                    Cancelar edición
+                  </button>
+                </div>
+                <p
+                  id="event-feedback"
+                  class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+                ></p>
+              </form>
+
+              <div class="grid gap-6 lg:grid-cols-2">
+                <div class="space-y-3">
+                  <h5 class="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Agenda registrada
+                  </h5>
+                  <ul id="event-list" class="space-y-3 text-sm text-slate-200"></ul>
+                </div>
+                <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                  <h5 class="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Vista previa rápida
+                  </h5>
+                  <div class="space-y-3">
+                    <div>
+                      <p class="text-[11px] font-semibold uppercase tracking-wide text-amber-300">
+                        Borradores
+                      </p>
+                      <div id="event-preview-draft" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+                    </div>
+                    <div>
+                      <p class="text-[11px] font-semibold uppercase tracking-wide text-emerald-300">
+                        Publicados
+                      </p>
+                      <div id="event-preview-published" class="mt-2 space-y-2 text-xs text-slate-300"></div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -357,141 +590,77 @@ import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
         </section>
 
         <section
+          aria-labelledby="media-library-title"
           class="hidden space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
-          aria-labelledby="event-manager"
-          data-view-panel="events"
+          data-view-panel="media-library"
         >
           <div>
-            <h3 id="event-manager" class="text-lg font-semibold text-teal-200">
-              Eventos y actividades
+            <h3 id="media-library-title" class="text-lg font-semibold text-teal-200">
+              Media Library
             </h3>
             <p class="mt-1 text-sm text-slate-400">
-              Programa talleres, ferias y encuentros manteniendo una vista previa antes de publicar.
+              Registra imágenes, documentos y recursos multimedia para reutilizarlos en tus colecciones.
             </p>
           </div>
 
-          <form id="event-form" class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
-            <input type="hidden" name="eventId" />
+          <form id="media-upload-form" class="grid gap-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4 md:grid-cols-2">
             <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Título del evento</span>
+              <span class="mb-1 block font-medium text-slate-300">Nombre</span>
               <input
-                name="title"
-                required
+                name="name"
+                placeholder="Banner convocatoria"
                 class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
               />
             </label>
             <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Descripción corta</span>
-              <textarea
-                name="shortDescription"
-                rows="3"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              ></textarea>
-            </label>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Descripción completa</span>
-              <textarea
-                name="description"
-                rows="4"
-                placeholder="Redacta cada bloque en una nueva línea"
-                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-              ></textarea>
-            </label>
-            <div class="grid gap-4 md:grid-cols-2">
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Fecha</span>
-                <input
-                  name="date"
-                  type="date"
-                  required
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Ubicación</span>
-                <input
-                  name="location"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Imagen (URL)</span>
-                <input
-                  name="image"
-                  type="url"
-                  placeholder="https://..."
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-              <label class="block text-sm">
-                <span class="mb-1 block font-medium text-slate-300">Etiquetas</span>
-                <input
-                  name="tags"
-                  placeholder="separa con comas"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-                />
-              </label>
-            </div>
-            <label class="block text-sm">
-              <span class="mb-1 block font-medium text-slate-300">Estado</span>
+              <span class="mb-1 block font-medium text-slate-300">Tipo</span>
               <select
-                name="status"
+                name="type"
                 class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
               >
-                <option value="draft">Borrador</option>
-                <option value="published">Publicado</option>
+                <option value="image">Imagen</option>
+                <option value="video">Video</option>
+                <option value="document">Documento</option>
               </select>
             </label>
-            <div class="flex flex-wrap items-center gap-3">
+            <label class="block text-sm md:col-span-2">
+              <span class="mb-1 block font-medium text-slate-300">URL pública</span>
+              <input
+                name="url"
+                required
+                placeholder="https://..."
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <label class="block text-sm md:col-span-2">
+              <span class="mb-1 block font-medium text-slate-300">Texto alternativo</span>
+              <input
+                name="altText"
+                placeholder="Describe el contenido para lectores de pantalla"
+                class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+              />
+            </label>
+            <div class="md:col-span-2 flex flex-wrap items-center gap-3">
               <button
                 type="submit"
                 class="rounded-lg bg-teal-500 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
               >
-                Guardar evento
+                Registrar archivo
               </button>
-              <button
-                type="button"
-                id="cancel-event-edit"
-                class="hidden rounded-lg border border-slate-700 px-3 py-2 text-xs font-medium text-slate-300 transition hover:border-slate-500"
-              >
-                Cancelar edición
-              </button>
+              <p
+                id="media-feedback"
+                class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
+              ></p>
             </div>
-            <p
-              id="event-feedback"
-              class="hidden rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm"
-            ></p>
           </form>
 
-          <div class="grid gap-6 lg:grid-cols-2">
-            <div class="space-y-3">
-              <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
-                Agenda registrada
-              </h4>
-              <ul id="event-list" class="space-y-3 text-sm text-slate-200"></ul>
-            </div>
-            <div class="space-y-4 rounded-lg border border-slate-800 bg-slate-950/40 p-4">
-              <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
-                Vista previa rápida
-              </h4>
-              <div class="space-y-3">
-                <div>
-                  <h5 class="text-xs font-semibold uppercase tracking-wide text-amber-300">
-                    Borradores
-                  </h5>
-                  <div id="event-preview-draft" class="mt-2 space-y-2 text-xs text-slate-300"></div>
-                </div>
-                <div>
-                  <h5 class="text-xs font-semibold uppercase tracking-wide text-emerald-300">
-                    Publicados
-                  </h5>
-                  <div id="event-preview-published" class="mt-2 space-y-2 text-xs text-slate-300"></div>
-                </div>
-              </div>
-            </div>
+          <div class="space-y-4">
+            <h4 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Biblioteca disponible
+            </h4>
+            <ul id="media-library-list" class="space-y-3 text-sm text-slate-200"></ul>
           </div>
         </section>
-
         <section
           id="user-management"
           class="hidden space-y-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6"
@@ -500,10 +669,10 @@ import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
         >
           <div>
             <h3 id="user-manager" class="text-lg font-semibold text-teal-200">
-              Gestión de usuarios y roles
+              Users, Roles & Permissions
             </h3>
             <p class="mt-1 text-sm text-slate-400">
-              Controla quién puede administrar contenidos o gestionar permisos.
+              Administra cuentas del dashboard, asigna roles y revisa las capacidades permitidas por cada perfil.
             </p>
           </div>
 

--- a/src/tests/adminStore.test.ts
+++ b/src/tests/adminStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createAdminStore } from "../utils/adminStore";
+import { createStrapiAdmin } from "../utils/strapiAdmin";
 
 function createStorage() {
   const map = new Map<string, string>();
@@ -16,10 +16,10 @@ function createStorage() {
   };
 }
 
-describe("adminStore", () => {
+describe("strapiAdmin", () => {
   const setup = () => {
     const storage = createStorage();
-    const store = createAdminStore(storage);
+    const store = createStrapiAdmin(storage);
     return { store, storage };
   };
 
@@ -30,123 +30,175 @@ describe("adminStore", () => {
     expect(store.getState().currentUserId).toBe(user.id);
   });
 
-  it("lanza error con credenciales incorrectas", () => {
-    const { store } = setup();
-    expect(() => store.login("admin", "wrong"))
-      .toThrowError(/Credenciales inválidas/);
-  });
-
-  it("permite al administrador crear y eliminar usuarios", () => {
+  it("gestiona el constructor de tipos de contenido", () => {
     const { store } = setup();
     store.login("admin", "admin123");
-    const newUser = store.createUser({
-      username: "editor-test",
+
+    const created = store.modules.contentTypeBuilder.create({
+      displayName: "Aliados",
+      description: "Directorio de organizaciones aliadas",
+      category: "Relaciones",
+      icon: "handshake",
+    });
+    expect(created.uid).toBe("aliados");
+    expect(created.configurable).toBe(true);
+
+    const field = store.modules.contentTypeBuilder.addField(created.uid, {
+      name: "Nombre",
+      type: "string",
+      required: true,
+      configurable: true,
+    });
+    expect(field.id).toBe("nombre");
+
+    const updated = store.modules.contentTypeBuilder.update(created.uid, {
+      description: "Red de cooperación interinstitucional",
+    });
+    expect(updated.description).toMatch(/cooperación/);
+
+    expect(() =>
+      store.modules.contentTypeBuilder.delete("sections")
+    ).toThrowError(/No es posible eliminar/);
+  });
+
+  it("respeta los permisos de publicación por rol", () => {
+    const { store } = setup();
+    store.login("admin", "admin123");
+    const eventEntry = store.modules.contentManager.createEntry("events", {
+      title: "Concierto comunitario",
+      shortDescription: "Encuentro cultural",
+      description: ["Programación musical"],
+      date: "2026-08-15",
+      image: "https://example.com/concierto.jpg",
+      location: "Centro cultural",
+      tags: ["cultura"],
+      status: "published",
+    });
+    expect(eventEntry.status).toBe("published");
+
+    const collaborator = store.modules.usersRolesPermissions.createUser({
+      username: "colab",
       password: "secret",
-      role: "Editor",
+      role: "Colaborador",
     });
-    expect(newUser.role).toBe("Editor");
-    expect(store.getState().users.some((user) => user.id === newUser.id)).toBe(
-      true
-    );
-
-    store.deleteUser(newUser.id);
-    expect(store.getState().users.some((user) => user.id === newUser.id)).toBe(
-      false
-    );
-  });
-
-  it("impide a un editor gestionar usuarios", () => {
-    const { store } = setup();
-    store.login("admin", "admin123");
-    store.createUser({ username: "solo-editor", password: "secret", role: "Editor" });
     store.logout();
-    store.login("solo-editor", "secret");
-    expect(store.canManageUsers()).toBe(false);
+    store.login(collaborator.username, "secret");
+
+    const draftEvent = store.modules.contentManager.createEntry("events", {
+      title: "Taller comunitario",
+      shortDescription: "Sesión participativa",
+      description: ["Descripción"],
+      date: "2026-09-01",
+      image: "https://example.com/taller.jpg",
+      location: "Quito",
+      tags: ["formación"],
+      status: "published",
+    });
+    expect(draftEvent.status).toBe("draft");
+
     expect(() =>
-      store.createUser({ username: "otro", password: "123", role: "Autor" })
+      store.modules.contentManager.updateEntry("events", draftEvent.id, {
+        status: "published",
+      })
     ).toThrowError(/Sin permisos/);
   });
 
-  it("controla las publicaciones de un colaborador", () => {
+  it("administra la biblioteca multimedia", () => {
     const { store } = setup();
     store.login("admin", "admin123");
-    store.createUser({ username: "colab", password: "secret", role: "Colaborador" });
-    store.logout();
-    store.login("colab", "secret");
-    const section = store.createSection({
-      title: "Borrador colaborador",
-      content: "Contenido de prueba",
-      status: "published",
+    const initial = store.modules.mediaLibrary.list().length;
+    const asset = store.modules.mediaLibrary.upload({
+      name: "Guía metodológica",
+      url: "https://example.com/guias/metodologia.pdf",
+      type: "document",
+      size: 1024,
     });
-    expect(section.status).toBe("draft");
-    expect(() =>
-      store.updateSection(section.id, { status: "published" })
-    ).toThrowError(/Sin permisos/);
+    expect(asset.type).toBe("document");
+
+    const updated = store.modules.mediaLibrary.update(asset.id, {
+      altText: "Manual de trabajo comunitario",
+    });
+    expect(updated.altText).toMatch(/Manual/);
+
+    store.modules.mediaLibrary.remove(asset.id);
+    expect(store.modules.mediaLibrary.list().length).toBe(initial);
   });
 
-  it("evita que un autor edite secciones ajenas", () => {
+  it("gestiona colecciones personalizadas", () => {
     const { store } = setup();
     store.login("admin", "admin123");
-    store.createUser({ username: "autor", password: "secret", role: "Autor" });
-    const foreignSection = store.createSection({
-      title: "Sección admin",
-      content: "Contenido",
-      status: "published",
+
+    const partnersType = store.modules.contentTypeBuilder.create({
+      displayName: "Programas",
+      description: "Listado de programas estratégicos",
+      icon: "layout",
+      fields: [
+        {
+          id: "titulo",
+          name: "Título",
+          type: "string",
+          required: true,
+          configurable: true,
+        },
+        {
+          id: "resumen",
+          name: "Resumen",
+          type: "text",
+          required: false,
+          configurable: true,
+        },
+      ],
     });
-    store.logout();
-    store.login("autor", "secret");
-    const ownSection = store.createSection({
-      title: "Sección propia",
-      content: "Contenido del autor",
+
+    const entry = store.modules.contentManager.createEntry(partnersType.uid, {
+      titulo: "Escuela de saberes",
+      resumen: "Formación popular y memoria viva",
       status: "draft",
     });
-    expect(ownSection.ownerId).not.toBe(foreignSection.ownerId);
-    expect(() =>
-      store.updateSection(foreignSection.id, { title: "Hack" })
-    ).toThrowError(/Sin permisos/);
-  });
+    expect(entry.status).toBe("draft");
 
-  it("impide que un moderador elimine secciones", () => {
-    const { store } = setup();
-    store.login("moderador", "mod123");
-    const state = store.getState();
-    const target = state.sections[0];
-    expect(() => store.deleteSection(target.id)).toThrowError(/Sin permisos/);
-  });
-
-  it("permite a un editor eliminar secciones", () => {
-    const { store } = setup();
-    store.login("admin", "admin123");
-    store.createUser({ username: "editor", password: "secret", role: "Editor" });
-    const section = store.createSection({
-      title: "Sección a eliminar",
-      content: "Contenido",
-      status: "published",
-    });
-    store.logout();
-    store.login("editor", "secret");
-    expect(() => store.deleteSection(section.id)).not.toThrow();
-    expect(store.getState().sections.some((item) => item.id === section.id)).toBe(
-      false
+    const published = store.modules.contentManager.setStatus(
+      partnersType.uid,
+      entry.id,
+      "published"
     );
+    expect(published.status).toBe("published");
+
+    const updated = store.modules.contentManager.updateEntry(partnersType.uid, entry.id, {
+      resumen: "Formación popular afrodescendiente",
+    });
+    expect(updated.attributes.resumen).toMatch(/afrodescendiente/);
+
+    store.modules.contentManager.deleteEntry(partnersType.uid, entry.id);
+    expect(
+      store.modules.contentManager.listEntries(partnersType.uid).length
+    ).toBe(0);
   });
 
-  it("persiste los datos en el almacenamiento proporcionado", () => {
+  it("persiste la configuración de los módulos", () => {
     const storage = createStorage();
-    const storeA = createAdminStore(storage);
+    const storeA = createStrapiAdmin(storage);
     storeA.login("admin", "admin123");
-    storeA.createUser({ username: "persistente", password: "secret", role: "Autor" });
-    const section = storeA.createSection({
-      title: "Sección persistente",
-      content: "Contenido",
+    const type = storeA.modules.contentTypeBuilder.create({
+      displayName: "Aliados territoriales",
+      description: "Organizaciones acompañantes",
+      icon: "map",
+    });
+    storeA.modules.contentManager.createEntry(type.uid, {
+      nombre: "Red de Mujeres del Pacífico",
       status: "draft",
     });
+    storeA.modules.mediaLibrary.upload({
+      name: "Logo Aliado",
+      url: "https://example.com/logo.png",
+    });
 
-    const storeB = createAdminStore(storage);
-    const state = storeB.getState();
-    expect(state.users.some((user) => user.username === "persistente")).toBe(
-      true
-    );
-    expect(state.sections.some((item) => item.id === section.id)).toBe(true);
+    const storeB = createStrapiAdmin(storage);
+    storeB.login("admin", "admin123");
+    const collections = storeB.modules.contentManager.listCollections();
+    expect(collections.some((item) => item.uid === type.uid)).toBe(true);
+    const entries = storeB.modules.contentManager.listEntries(type.uid);
+    expect(entries.length).toBe(1);
+    expect(storeB.modules.mediaLibrary.list().some((asset) => asset.url.endsWith("logo.png"))).toBe(true);
   });
 });

--- a/src/utils/adminStore.ts
+++ b/src/utils/adminStore.ts
@@ -54,7 +54,7 @@ export interface StorageLike {
 
 const STORAGE_KEY = "funteco-admin-state";
 
-const ROLE_CAPABILITIES: Record<
+export const ROLE_CAPABILITIES: Record<
   Role,
   {
     manageUsers: boolean;

--- a/src/utils/strapiAdmin.ts
+++ b/src/utils/strapiAdmin.ts
@@ -1,0 +1,965 @@
+import {
+  createAdminStore,
+  ROLES,
+  ROLE_CAPABILITIES,
+  type AdminStore,
+  type ManagedEvent,
+  type ManagedTeamMember,
+  type Role,
+  type Section,
+  type SectionStatus,
+  type StorageLike,
+  type User,
+} from "./adminStore";
+import type { SocialLink } from "../data/team";
+
+export type MediaType = "image" | "video" | "document";
+
+export type ContentFieldType =
+  | "string"
+  | "text"
+  | "richtext"
+  | "uid"
+  | "media"
+  | "enumeration"
+  | "json"
+  | "date"
+  | "datetime"
+  | "boolean"
+  | "number"
+  | "relation";
+
+export type ContentTypeUID = "sections" | "team-members" | "events" | (string & {});
+
+export interface ContentTypeField {
+  id: string;
+  name: string;
+  type: ContentFieldType;
+  required: boolean;
+  configurable: boolean;
+  defaultValue?: unknown;
+  options?: Record<string, unknown>;
+}
+
+export interface ContentTypeDefinition {
+  uid: ContentTypeUID;
+  displayName: string;
+  description: string;
+  category: string;
+  icon: string;
+  draftAndPublish: boolean;
+  kind: "collectionType";
+  configurable: boolean;
+  fields: ContentTypeField[];
+}
+
+export interface ContentEntry<TAttributes = Record<string, unknown>> {
+  id: string;
+  contentType: ContentTypeUID;
+  status: SectionStatus;
+  ownerId: string;
+  createdAt: string;
+  updatedAt: string;
+  attributes: TAttributes;
+}
+
+export type CustomEntry = ContentEntry<Record<string, unknown>>;
+
+export interface MediaAsset {
+  id: string;
+  name: string;
+  url: string;
+  type: MediaType;
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  altText?: string;
+}
+
+const MODULE_STORAGE_KEY = "funteco-strapi-modules";
+const BUILT_IN_COLLECTIONS = new Set<ContentTypeUID>([
+  "sections",
+  "team-members",
+  "events",
+]);
+const FIELD_TYPES = new Set<ContentFieldType>([
+  "string",
+  "text",
+  "richtext",
+  "uid",
+  "media",
+  "enumeration",
+  "json",
+  "date",
+  "datetime",
+  "boolean",
+  "number",
+  "relation",
+]);
+
+const SYSTEM_CATEGORY = "Colecciones FunTeco";
+const CUSTOM_CATEGORY = "Colecciones personalizadas";
+
+interface ModuleState {
+  contentTypes: ContentTypeDefinition[];
+  customCollections: Record<string, CustomEntry[]>;
+  mediaLibrary: MediaAsset[];
+}
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+
+const createId = () =>
+  typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : Math.random().toString(36).slice(2, 10);
+
+const mapSectionToEntry = (section: Section): ContentEntry<Omit<Section, "id">> => ({
+  id: section.id,
+  contentType: "sections",
+  status: section.status,
+  ownerId: section.ownerId,
+  createdAt: section.updatedAt,
+  updatedAt: section.updatedAt,
+  attributes: {
+    title: section.title,
+    slug: section.slug,
+    content: section.content,
+    status: section.status,
+    ownerId: section.ownerId,
+    updatedAt: section.updatedAt,
+  },
+});
+
+const mapTeamMemberToEntry = (
+  member: ManagedTeamMember
+): ContentEntry<Omit<ManagedTeamMember, "id" | "status" | "ownerId" | "createdAt" | "updatedAt">> => ({
+  id: member.id,
+  contentType: "team-members",
+  status: member.status,
+  ownerId: member.ownerId,
+  createdAt: member.createdAt,
+  updatedAt: member.updatedAt,
+  attributes: {
+    slug: member.slug,
+    name: member.name,
+    role: member.role,
+    image: member.image,
+    shortBio: member.shortBio,
+    bio: member.bio,
+    focus: member.focus,
+    expertise: member.expertise,
+    highlights: member.highlights,
+    socials: member.socials,
+  },
+});
+
+const mapEventToEntry = (
+  event: ManagedEvent
+): ContentEntry<Omit<ManagedEvent, "id" | "status" | "ownerId" | "createdAt" | "updatedAt">> => ({
+  id: event.id,
+  contentType: "events",
+  status: event.status,
+  ownerId: event.ownerId,
+  createdAt: event.createdAt,
+  updatedAt: event.updatedAt,
+  attributes: {
+    slug: event.slug,
+    title: event.title,
+    shortDescription: event.shortDescription,
+    description: event.description,
+    date: event.date,
+    formattedDate: event.formattedDate,
+    image: event.image,
+    location: event.location,
+    tags: event.tags,
+  },
+});
+
+const createDefaultContentTypes = (): ContentTypeDefinition[] => [
+  {
+    uid: "sections",
+    displayName: "Secciones del sitio",
+    description:
+      "Componentes editoriales que alimentan el hero, llamados a la acción y otros bloques informativos.",
+    category: SYSTEM_CATEGORY,
+    icon: "align-left",
+    draftAndPublish: true,
+    kind: "collectionType",
+    configurable: false,
+    fields: [
+      {
+        id: "title",
+        name: "Título",
+        type: "string",
+        required: true,
+        configurable: true,
+      },
+      {
+        id: "slug",
+        name: "Slug",
+        type: "uid",
+        required: true,
+        configurable: false,
+      },
+      {
+        id: "content",
+        name: "Contenido",
+        type: "richtext",
+        required: true,
+        configurable: true,
+      },
+      {
+        id: "status",
+        name: "Estado",
+        type: "enumeration",
+        required: true,
+        configurable: true,
+        options: { values: ["draft", "published"] },
+      },
+    ],
+  },
+  {
+    uid: "team-members",
+    displayName: "Integrantes del equipo",
+    description:
+      "Perfiles con biografías ampliadas, galerías multimedia y enlaces a redes sociales.",
+    category: SYSTEM_CATEGORY,
+    icon: "users",
+    draftAndPublish: true,
+    kind: "collectionType",
+    configurable: false,
+    fields: [
+      { id: "name", name: "Nombre", type: "string", required: true, configurable: true },
+      { id: "slug", name: "Slug", type: "uid", required: true, configurable: false },
+      { id: "role", name: "Rol", type: "string", required: true, configurable: true },
+      { id: "image", name: "Imagen", type: "media", required: true, configurable: true },
+      { id: "shortBio", name: "Resumen", type: "text", required: true, configurable: true },
+      { id: "bio", name: "Biografía", type: "json", required: true, configurable: true },
+      { id: "focus", name: "Enfoque", type: "string", required: true, configurable: true },
+      { id: "expertise", name: "Experticias", type: "json", required: true, configurable: true },
+      { id: "highlights", name: "Logros", type: "json", required: true, configurable: true },
+      { id: "socials", name: "Redes", type: "json", required: false, configurable: true },
+      {
+        id: "status",
+        name: "Estado",
+        type: "enumeration",
+        required: true,
+        configurable: true,
+        options: { values: ["draft", "published"] },
+      },
+    ],
+  },
+  {
+    uid: "events",
+    displayName: "Eventos y actividades",
+    description: "Agenda programática y experiencias formativas de la fundación.",
+    category: SYSTEM_CATEGORY,
+    icon: "calendar",
+    draftAndPublish: true,
+    kind: "collectionType",
+    configurable: false,
+    fields: [
+      { id: "title", name: "Título", type: "string", required: true, configurable: true },
+      { id: "slug", name: "Slug", type: "uid", required: true, configurable: false },
+      { id: "shortDescription", name: "Descripción corta", type: "text", required: true, configurable: true },
+      { id: "description", name: "Descripción", type: "json", required: true, configurable: true },
+      { id: "date", name: "Fecha", type: "date", required: true, configurable: true },
+      { id: "image", name: "Imagen", type: "media", required: true, configurable: true },
+      { id: "location", name: "Ubicación", type: "string", required: true, configurable: true },
+      { id: "tags", name: "Etiquetas", type: "json", required: false, configurable: true },
+      {
+        id: "status",
+        name: "Estado",
+        type: "enumeration",
+        required: true,
+        configurable: true,
+        options: { values: ["draft", "published"] },
+      },
+    ],
+  },
+];
+
+const createDefaultMediaLibrary = (
+  teamMembers: ManagedTeamMember[],
+  events: ManagedEvent[],
+  author: string
+): MediaAsset[] => {
+  const assets = new Map<string, MediaAsset>();
+  const register = (url: string, name: string) => {
+    if (!url || assets.has(url)) return;
+    assets.set(url, {
+      id: `asset-${assets.size + 1}`,
+      name,
+      url,
+      type: "image",
+      size: 0,
+      createdAt: new Date(2023, 0, assets.size + 1).toISOString(),
+      updatedAt: new Date(2023, 0, assets.size + 1).toISOString(),
+      createdBy: author,
+    });
+  };
+  teamMembers.forEach((member) => register(member.image, member.name));
+  events.forEach((event) => register(event.image, event.title));
+  return Array.from(assets.values());
+};
+
+const createDefaultModuleState = (legacyState: ReturnType<AdminStore["getState"]>): ModuleState => ({
+  contentTypes: createDefaultContentTypes(),
+  customCollections: {},
+  mediaLibrary: createDefaultMediaLibrary(
+    legacyState.teamMembers,
+    legacyState.events,
+    legacyState.users[0]?.username ?? "admin"
+  ),
+});
+
+const loadModuleState = (
+  storage: StorageLike | undefined,
+  legacyState: ReturnType<AdminStore["getState"]>
+): ModuleState => {
+  const defaults = createDefaultModuleState(legacyState);
+  if (!storage) return defaults;
+  try {
+    const raw = storage.getItem(MODULE_STORAGE_KEY);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw) as Partial<ModuleState>;
+    const storedTypes = Array.isArray(parsed.contentTypes)
+      ? (parsed.contentTypes as ContentTypeDefinition[])
+      : [];
+    const typeMap = new Map<string, ContentTypeDefinition>();
+    defaults.contentTypes.forEach((type) => typeMap.set(type.uid, type));
+    storedTypes.forEach((type) => {
+      const base = typeMap.get(type.uid);
+      typeMap.set(type.uid, {
+        ...base,
+        ...type,
+        configurable: base?.configurable ?? type.configurable ?? true,
+        fields: Array.isArray(type.fields) ? type.fields : base?.fields ?? [],
+      } as ContentTypeDefinition);
+    });
+    const contentTypes = Array.from(typeMap.values());
+    const customCollections = parsed.customCollections
+      ? Object.fromEntries(
+          Object.entries(parsed.customCollections).map(([uid, entries]) => [
+            uid,
+            Array.isArray(entries)
+              ? (entries as CustomEntry[])
+              : defaults.customCollections[uid] ?? [],
+          ])
+        )
+      : defaults.customCollections;
+    const mediaLibrary = Array.isArray(parsed.mediaLibrary)
+      ? (parsed.mediaLibrary as MediaAsset[])
+      : defaults.mediaLibrary;
+    return { contentTypes, customCollections, mediaLibrary };
+  } catch (error) {
+    console.warn("No se pudo cargar el estado de los módulos Strapi", error);
+    return defaults;
+  }
+};
+
+const persistModuleState = (storage: StorageLike | undefined, state: ModuleState) => {
+  if (!storage) return;
+  storage.setItem(MODULE_STORAGE_KEY, JSON.stringify(state));
+};
+
+const ensure = (condition: boolean, message: string) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const toSectionStatus = (value: unknown, fallback: SectionStatus = "draft"): SectionStatus => {
+  if (value === "published" || value === "draft") {
+    return value;
+  }
+  return fallback;
+};
+
+const sanitizeFieldId = (name: string, existing: ContentTypeField[]): string => {
+  const base = slugify(name);
+  let candidate = base || `field-${existing.length + 1}`;
+  let index = 1;
+  while (existing.some((field) => field.id === candidate)) {
+    candidate = `${base}-${index++}`;
+  }
+  return candidate;
+};
+
+const getCurrentUser = (store: AdminStore): User | null => {
+  const state = store.getState();
+  return state.users.find((user) => user.id === state.currentUserId) ?? null;
+};
+
+const registerAssetIfNeeded = (
+  state: ModuleState,
+  payload: { url?: string; name: string; author: string }
+) => {
+  if (!payload.url) return;
+  const exists = state.mediaLibrary.some((asset) => asset.url === payload.url);
+  if (exists) return;
+  const now = new Date().toISOString();
+  state.mediaLibrary.push({
+    id: `asset-${state.mediaLibrary.length + 1}-${createId()}`,
+    name: payload.name,
+    url: payload.url,
+    type: "image",
+    size: 0,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: payload.author,
+  });
+};
+
+export interface ContentTypeBuilderModule {
+  list(): ContentTypeDefinition[];
+  get(uid: ContentTypeUID): ContentTypeDefinition | undefined;
+  create(
+    data: Omit<ContentTypeDefinition, "uid" | "kind" | "draftAndPublish" | "fields" | "configurable"> &
+      Partial<Pick<ContentTypeDefinition, "draftAndPublish" | "fields">>
+  ): ContentTypeDefinition;
+  update(
+    uid: ContentTypeUID,
+    updates: Partial<Omit<ContentTypeDefinition, "uid" | "fields" | "kind">>
+  ): ContentTypeDefinition;
+  delete(uid: ContentTypeUID): void;
+  addField(
+    uid: ContentTypeUID,
+    field: Omit<ContentTypeField, "id"> & { id?: string }
+  ): ContentTypeField;
+  updateField(
+    uid: ContentTypeUID,
+    fieldId: string,
+    updates: Partial<Omit<ContentTypeField, "id">>
+  ): ContentTypeField;
+  removeField(uid: ContentTypeUID, fieldId: string): void;
+}
+
+export interface ContentManagerModule {
+  listCollections(): ContentTypeDefinition[];
+  listEntries(uid: ContentTypeUID): ContentEntry[];
+  getEntry(uid: ContentTypeUID, id: string): ContentEntry | undefined;
+  createEntry(uid: ContentTypeUID, data: Record<string, unknown>): ContentEntry;
+  updateEntry(
+    uid: ContentTypeUID,
+    id: string,
+    updates: Record<string, unknown>
+  ): ContentEntry;
+  deleteEntry(uid: ContentTypeUID, id: string): void;
+  setStatus(uid: ContentTypeUID, id: string, status: SectionStatus): ContentEntry;
+}
+
+export interface MediaLibraryModule {
+  list(): MediaAsset[];
+  upload(data: { name: string; url: string; type?: MediaType; size?: number; altText?: string }): MediaAsset;
+  update(id: string, updates: Partial<Omit<MediaAsset, "id" | "createdAt" | "createdBy">>): MediaAsset;
+  remove(id: string): void;
+}
+
+export interface UsersRolesPermissionsModule {
+  listRoles(): Role[];
+  listUsers(): User[];
+  getRoleCapabilities(role: Role): (typeof ROLE_CAPABILITIES)[Role];
+  currentUser(): User | null;
+  createUser(data: Omit<User, "id" | "createdAt"> & { password: string }): User;
+  updateUser(id: string, updates: Partial<Pick<User, "password" | "role">>): User;
+  deleteUser(id: string): void;
+  assignRole(id: string, role: Role): User;
+  canCurrentUserManageUsers(): boolean;
+}
+
+export interface StrapiAdminStore extends AdminStore {
+  modules: {
+    contentTypeBuilder: ContentTypeBuilderModule;
+    contentManager: ContentManagerModule;
+    mediaLibrary: MediaLibraryModule;
+    usersRolesPermissions: UsersRolesPermissionsModule;
+  };
+}
+
+export const createStrapiAdmin = (
+  storage?: StorageLike
+): StrapiAdminStore => {
+  const legacyStore = createAdminStore(storage);
+  let moduleState = loadModuleState(storage, legacyStore.getState());
+
+  const persist = () => persistModuleState(storage, moduleState);
+
+  const contentTypeBuilder: ContentTypeBuilderModule = {
+    list() {
+      return clone(moduleState.contentTypes);
+    },
+    get(uid) {
+      return clone(moduleState.contentTypes.find((type) => type.uid === uid));
+    },
+    create(data) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para crear tipos de contenido"
+      );
+      const uid = (data.uid as ContentTypeUID) ?? (slugify(data.displayName) as ContentTypeUID);
+      ensure(uid.length > 0, "El nombre interno del tipo no puede estar vacío");
+      ensure(
+        !moduleState.contentTypes.some((type) => type.uid === uid),
+        "Ya existe un tipo de contenido con ese UID"
+      );
+      const fields = Array.isArray(data.fields) ? data.fields : [];
+      const definition: ContentTypeDefinition = {
+        uid,
+        displayName: data.displayName,
+        description: data.description,
+        category: data.category ?? CUSTOM_CATEGORY,
+        icon: data.icon ?? "database",
+        draftAndPublish: data.draftAndPublish ?? true,
+        kind: "collectionType",
+        configurable: true,
+        fields: fields.map((field, index) => ({
+          ...field,
+          id: field.id ?? `field-${index + 1}`,
+        })),
+      };
+      moduleState.contentTypes = [...moduleState.contentTypes, definition];
+      moduleState.customCollections[uid] = [];
+      persist();
+      return clone(definition);
+    },
+    update(uid, updates) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para editar tipos de contenido"
+      );
+      const index = moduleState.contentTypes.findIndex((type) => type.uid === uid);
+      ensure(index >= 0, "Tipo de contenido no encontrado");
+      const definition = moduleState.contentTypes[index];
+      ensure(definition.configurable, "El tipo de contenido no es editable");
+      const updated: ContentTypeDefinition = {
+        ...definition,
+        ...updates,
+        fields: definition.fields,
+      };
+      moduleState.contentTypes[index] = updated;
+      persist();
+      return clone(updated);
+    },
+    delete(uid) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para eliminar tipos de contenido"
+      );
+      const type = moduleState.contentTypes.find((candidate) => candidate.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      ensure(type.configurable, "No es posible eliminar un tipo del sistema");
+      moduleState.contentTypes = moduleState.contentTypes.filter((item) => item.uid !== uid);
+      delete moduleState.customCollections[uid];
+      persist();
+    },
+    addField(uid, field) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para gestionar campos"
+      );
+      ensure(FIELD_TYPES.has(field.type), "Tipo de campo no admitido");
+      const type = moduleState.contentTypes.find((item) => item.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      ensure(type.configurable, "El tipo de contenido no permite modificaciones");
+      const id = field.id ?? sanitizeFieldId(field.name, type.fields);
+      ensure(
+        !type.fields.some((candidate) => candidate.id === id),
+        "Ya existe un campo con ese identificador"
+      );
+      const definition: ContentTypeField = {
+        id,
+        name: field.name,
+        type: field.type,
+        required: field.required ?? false,
+        configurable: field.configurable ?? true,
+        defaultValue: field.defaultValue,
+        options: field.options,
+      };
+      type.fields = [...type.fields, definition];
+      persist();
+      return clone(definition);
+    },
+    updateField(uid, fieldId, updates) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para editar campos"
+      );
+      const type = moduleState.contentTypes.find((item) => item.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      ensure(type.configurable, "El tipo de contenido no permite modificaciones");
+      const index = type.fields.findIndex((field) => field.id === fieldId);
+      ensure(index >= 0, "Campo no encontrado");
+      const field = type.fields[index];
+      if (updates.type) {
+        ensure(FIELD_TYPES.has(updates.type), "Tipo de campo no admitido");
+      }
+      type.fields[index] = {
+        ...field,
+        ...updates,
+      };
+      persist();
+      return clone(type.fields[index]);
+    },
+    removeField(uid, fieldId) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(
+        !!currentUser && ROLE_CAPABILITIES[currentUser.role].manageUsers,
+        "Sin permisos para eliminar campos"
+      );
+      const type = moduleState.contentTypes.find((item) => item.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      ensure(type.configurable, "El tipo de contenido no permite modificaciones");
+      ensure(type.fields.some((field) => field.id === fieldId), "Campo no encontrado");
+      type.fields = type.fields.filter((field) => field.id !== fieldId);
+      persist();
+    },
+  };
+
+  const mapCustomEntry = (entry: CustomEntry): ContentEntry => clone(entry);
+
+  const listEntries = (uid: ContentTypeUID): ContentEntry[] => {
+    if (uid === "sections") {
+      return legacyStore.getState().sections.map(mapSectionToEntry);
+    }
+    if (uid === "team-members") {
+      return legacyStore.getState().teamMembers.map(mapTeamMemberToEntry);
+    }
+    if (uid === "events") {
+      return legacyStore.getState().events.map(mapEventToEntry);
+    }
+    return (moduleState.customCollections[uid] ?? []).map(mapCustomEntry);
+  };
+
+  const contentManager: ContentManagerModule = {
+    listCollections() {
+      return clone(moduleState.contentTypes);
+    },
+    listEntries(uid) {
+      return listEntries(uid);
+    },
+    getEntry(uid, id) {
+      return this.listEntries(uid).find((entry) => entry.id === id);
+    },
+    createEntry(uid, data) {
+      if (uid === "sections") {
+        const section = legacyStore.createSection({
+          title: String(data.title ?? ""),
+          content: String(data.content ?? ""),
+          status: toSectionStatus(data.status),
+        });
+        persist();
+        return mapSectionToEntry(section);
+      }
+      if (uid === "team-members") {
+        const member = legacyStore.createTeamMember({
+          name: String(data.name ?? ""),
+          role: String(data.role ?? ""),
+          image: String(data.image ?? ""),
+          shortBio: String(data.shortBio ?? ""),
+          bio: Array.isArray(data.bio)
+            ? (data.bio as string[])
+            : String(data.bio ?? "").split(/\r?\n/).filter(Boolean),
+          focus: String(data.focus ?? ""),
+          expertise: Array.isArray(data.expertise)
+            ? (data.expertise as string[])
+            : String(data.expertise ?? "").split(",").map((item) => item.trim()).filter(Boolean),
+          highlights: Array.isArray(data.highlights)
+            ? (data.highlights as string[])
+            : String(data.highlights ?? "").split(/\r?\n/).filter(Boolean),
+          socials: (Array.isArray(data.socials) ? data.socials : []) as SocialLink[],
+          status: toSectionStatus(data.status),
+        });
+        registerAssetIfNeeded(moduleState, {
+          url: member.image,
+          name: member.name,
+          author: getCurrentUser(legacyStore)?.username ?? "admin",
+        });
+        persist();
+        return mapTeamMemberToEntry(member);
+      }
+      if (uid === "events") {
+        const event = legacyStore.createEvent({
+          title: String(data.title ?? ""),
+          shortDescription: String(data.shortDescription ?? ""),
+          description: Array.isArray(data.description)
+            ? (data.description as string[])
+            : String(data.description ?? "").split(/\r?\n/).filter(Boolean),
+          date: String(data.date ?? new Date().toISOString()),
+          image: String(data.image ?? ""),
+          location: String(data.location ?? ""),
+          tags: Array.isArray(data.tags)
+            ? (data.tags as string[])
+            : String(data.tags ?? "").split(",").map((item) => item.trim()).filter(Boolean),
+          status: toSectionStatus(data.status, "draft"),
+        });
+        registerAssetIfNeeded(moduleState, {
+          url: event.image,
+          name: event.title,
+          author: getCurrentUser(legacyStore)?.username ?? "admin",
+        });
+        persist();
+        return mapEventToEntry(event);
+      }
+      const type = moduleState.contentTypes.find((candidate) => candidate.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(!!currentUser, "Debes iniciar sesión para crear registros");
+      const requiredFields = type.fields.filter((field) => field.required);
+      requiredFields.forEach((field) => {
+        ensure(data[field.id] !== undefined && data[field.id] !== null, `El campo ${field.name} es obligatorio`);
+      });
+      const now = new Date().toISOString();
+      const status = type.draftAndPublish ? toSectionStatus(data.status) : "published";
+      const entry: CustomEntry = {
+        id: `entry-${createId()}`,
+        contentType: uid,
+        status,
+        ownerId: currentUser.id,
+        createdAt: now,
+        updatedAt: now,
+        attributes: Object.fromEntries(
+          Object.entries(data).filter(([key]) => key !== "status")
+        ),
+      };
+      if (!moduleState.customCollections[uid]) {
+        moduleState.customCollections[uid] = [];
+      }
+      moduleState.customCollections[uid] = [entry, ...moduleState.customCollections[uid]];
+      const mediaFields = type.fields.filter((field) => field.type === "media");
+      mediaFields.forEach((field) => {
+        const url = data[field.id];
+        if (typeof url === "string") {
+          registerAssetIfNeeded(moduleState, {
+            url,
+            name: `${type.displayName}: ${field.name}`,
+            author: currentUser.username,
+          });
+        }
+      });
+      persist();
+      return clone(entry);
+    },
+    updateEntry(uid, id, updates) {
+      if (uid === "sections") {
+        const section = legacyStore.updateSection(id, {
+          title: updates.title as string | undefined,
+          content: updates.content as string | undefined,
+          status: updates.status as SectionStatus | undefined,
+        });
+        persist();
+        return mapSectionToEntry(section);
+      }
+      if (uid === "team-members") {
+        const member = legacyStore.updateTeamMember(id, {
+          name: updates.name as string | undefined,
+          role: updates.role as string | undefined,
+          image: updates.image as string | undefined,
+          shortBio: updates.shortBio as string | undefined,
+          bio: updates.bio as string[] | undefined,
+          focus: updates.focus as string | undefined,
+          expertise: updates.expertise as string[] | undefined,
+          highlights: updates.highlights as string[] | undefined,
+          socials: updates.socials as SocialLink[] | undefined,
+          status: updates.status as SectionStatus | undefined,
+        });
+        if (updates.image) {
+          registerAssetIfNeeded(moduleState, {
+            url: String(updates.image),
+            name: member.name,
+            author: getCurrentUser(legacyStore)?.username ?? "admin",
+          });
+        }
+        persist();
+        return mapTeamMemberToEntry(member);
+      }
+      if (uid === "events") {
+        const event = legacyStore.updateEvent(id, {
+          title: updates.title as string | undefined,
+          shortDescription: updates.shortDescription as string | undefined,
+          description: updates.description as string[] | undefined,
+          date: updates.date as string | undefined,
+          image: updates.image as string | undefined,
+          location: updates.location as string | undefined,
+          tags: updates.tags as string[] | undefined,
+          status: updates.status as SectionStatus | undefined,
+        });
+        if (updates.image) {
+          registerAssetIfNeeded(moduleState, {
+            url: String(updates.image),
+            name: event.title,
+            author: getCurrentUser(legacyStore)?.username ?? "admin",
+          });
+        }
+        persist();
+        return mapEventToEntry(event);
+      }
+      const type = moduleState.contentTypes.find((candidate) => candidate.uid === uid);
+      ensure(!!type, "Tipo de contenido no encontrado");
+      const collection = moduleState.customCollections[uid] ?? [];
+      const index = collection.findIndex((entry) => entry.id === id);
+      ensure(index >= 0, "Entrada no encontrada");
+      const entry = collection[index];
+      const newStatus = updates.status
+        ? toSectionStatus(updates.status as SectionStatus)
+        : entry.status;
+      const now = new Date().toISOString();
+      const attributes = {
+        ...entry.attributes,
+        ...Object.fromEntries(
+          Object.entries(updates).filter(([key]) => key !== "status")
+        ),
+      };
+      const updated: CustomEntry = {
+        ...entry,
+        status: type.draftAndPublish ? newStatus : "published",
+        updatedAt: now,
+        attributes,
+      };
+      moduleState.customCollections[uid][index] = updated;
+      persist();
+      return clone(updated);
+    },
+    deleteEntry(uid, id) {
+      if (uid === "sections") {
+        legacyStore.deleteSection(id);
+        persist();
+        return;
+      }
+      if (uid === "team-members") {
+        legacyStore.deleteTeamMember(id);
+        persist();
+        return;
+      }
+      if (uid === "events") {
+        legacyStore.deleteEvent(id);
+        persist();
+        return;
+      }
+      const collection = moduleState.customCollections[uid];
+      ensure(!!collection, "Tipo de contenido no encontrado");
+      const before = collection.length;
+      moduleState.customCollections[uid] = collection.filter((entry) => entry.id !== id);
+      ensure(before !== moduleState.customCollections[uid].length, "Entrada no encontrada");
+      persist();
+    },
+    setStatus(uid, id, status) {
+      if (uid === "sections") {
+        return this.updateEntry(uid, id, { status });
+      }
+      if (uid === "team-members") {
+        return this.updateEntry(uid, id, { status });
+      }
+      if (uid === "events") {
+        return this.updateEntry(uid, id, { status });
+      }
+      return this.updateEntry(uid, id, { status });
+    },
+  };
+
+  const mediaLibrary: MediaLibraryModule = {
+    list() {
+      return clone(moduleState.mediaLibrary);
+    },
+    upload(data) {
+      const currentUser = getCurrentUser(legacyStore);
+      ensure(!!currentUser, "Debes iniciar sesión para subir archivos");
+      ensure(data.url, "La URL del archivo es obligatoria");
+      const now = new Date().toISOString();
+      const asset: MediaAsset = {
+        id: `asset-${createId()}`,
+        name: data.name || data.url.split("/").pop() || "Archivo",
+        url: data.url,
+        type: data.type ?? "image",
+        size: data.size ?? 0,
+        altText: data.altText,
+        createdAt: now,
+        updatedAt: now,
+        createdBy: currentUser.username,
+      };
+      moduleState.mediaLibrary = [asset, ...moduleState.mediaLibrary.filter((item) => item.url !== asset.url)];
+      persist();
+      return clone(asset);
+    },
+    update(id, updates) {
+      const index = moduleState.mediaLibrary.findIndex((asset) => asset.id === id);
+      ensure(index >= 0, "Archivo multimedia no encontrado");
+      const asset = moduleState.mediaLibrary[index];
+      moduleState.mediaLibrary[index] = {
+        ...asset,
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+      persist();
+      return clone(moduleState.mediaLibrary[index]);
+    },
+    remove(id) {
+      const before = moduleState.mediaLibrary.length;
+      moduleState.mediaLibrary = moduleState.mediaLibrary.filter((asset) => asset.id !== id);
+      ensure(before !== moduleState.mediaLibrary.length, "Archivo multimedia no encontrado");
+      persist();
+    },
+  };
+
+  const usersRolesPermissions: UsersRolesPermissionsModule = {
+    listRoles() {
+      return [...ROLES];
+    },
+    listUsers() {
+      return clone(legacyStore.getState().users);
+    },
+    getRoleCapabilities(role) {
+      return ROLE_CAPABILITIES[role];
+    },
+    currentUser() {
+      return getCurrentUser(legacyStore);
+    },
+    createUser(data) {
+      const user = legacyStore.createUser(data);
+      persist();
+      return user;
+    },
+    updateUser(id, updates) {
+      const user = legacyStore.updateUser(id, updates);
+      persist();
+      return user;
+    },
+    deleteUser(id) {
+      legacyStore.deleteUser(id);
+      persist();
+    },
+    assignRole(id, role) {
+      return this.updateUser(id, { role });
+    },
+    canCurrentUserManageUsers() {
+      return legacyStore.canManageUsers();
+    },
+  };
+
+  return {
+    ...legacyStore,
+    modules: {
+      contentTypeBuilder,
+      contentManager,
+      mediaLibrary,
+      usersRolesPermissions,
+    },
+  };
+};
+
+export type { ModuleState };


### PR DESCRIPTION
## Summary
- add a Strapi-inspired admin store with content-type builder, media library, content manager and user/role modules
- refresh the admin dashboard UI to expose the new modules and update automated tests
- document the workflow and migrate project instructions to pnpm

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68de613765108323912180ea7bc92e4d