### PR TITLE
Separate admin login view with dedicated security tests

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -6,58 +6,12 @@ import adminDashboardScript from "../../scripts/adminDashboard.ts?url";
 <AdminLayout title="Centro de control">
   <div
     id="admin-app"
-    class="min-h-[720px] rounded-3xl border border-slate-800/60 bg-slate-950/70 shadow-2xl shadow-slate-950/60 ring-1 ring-slate-900/60"
+    data-auth-state="pending"
+    class="hidden min-h-[720px] rounded-3xl border border-slate-800/60 bg-slate-950/70 opacity-0 shadow-2xl shadow-slate-950/60 ring-1 ring-slate-900/60 transition-opacity"
   >
     <section
-      id="login-view"
-      class="flex h-full flex-col items-center justify-center gap-6 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-950/80 px-6 py-16 text-center"
-    >
-      <div class="w-full max-w-md space-y-6 rounded-3xl border border-slate-800/60 bg-slate-950/80 p-10 text-left shadow-xl">
-        <div class="space-y-2">
-          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Panel privado</p>
-          <h2 class="text-2xl font-semibold text-teal-200">Acceso al dashboard</h2>
-          <p class="text-sm text-slate-400">
-            Introduce tus credenciales internas para gestionar colecciones, contenidos y medios.
-          </p>
-        </div>
-        <form id="login-form" class="space-y-5">
-          <label class="block text-sm">
-            <span class="mb-1 block font-medium text-slate-200">Usuario</span>
-            <input
-              name="username"
-              type="text"
-              required
-              autocomplete="username"
-              class="w-full rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-            />
-          </label>
-          <label class="block text-sm">
-            <span class="mb-1 block font-medium text-slate-200">Contraseña</span>
-            <input
-              name="password"
-              type="password"
-              required
-              autocomplete="current-password"
-              class="w-full rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
-            />
-          </label>
-          <button
-            type="submit"
-            class="w-full rounded-xl bg-teal-400/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-teal-300 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
-          >
-            Entrar
-          </button>
-        </form>
-        <p
-          id="login-error"
-          class="hidden rounded-xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
-        ></p>
-      </div>
-    </section>
-
-    <section
       id="dashboard"
-      class="hidden h-full overflow-hidden rounded-3xl bg-slate-950/90 lg:grid lg:grid-cols-[240px_1fr]"
+      class="h-full overflow-hidden rounded-3xl bg-slate-950/90 lg:grid lg:grid-cols-[240px_1fr]"
     >
       <aside class="hidden flex-col border-r border-slate-800/80 bg-slate-950/95 px-6 py-8 lg:flex">
         <div class="flex items-center gap-3 pb-8">

--- a/src/pages/admin/login.astro
+++ b/src/pages/admin/login.astro
@@ -1,0 +1,60 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import adminLoginScript from "../../scripts/adminLogin.ts?url";
+---
+<AdminLayout title="Acceso administrativo">
+  <section
+    id="admin-login-app"
+    class="flex min-h-[540px] flex-col items-center justify-center gap-8 rounded-3xl border border-slate-800/60 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-950/80 px-6 py-16 text-center shadow-2xl shadow-slate-950/60 ring-1 ring-slate-900/60"
+  >
+    <div class="w-full max-w-md space-y-6 rounded-3xl border border-slate-800/60 bg-slate-950/80 p-10 text-left shadow-xl">
+      <header class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+          Panel privado
+        </p>
+        <h2 class="text-2xl font-semibold text-teal-200">Acceso al dashboard</h2>
+        <p class="text-sm text-slate-400">
+          Introduce tus credenciales internas para gestionar colecciones, contenidos y medios.
+        </p>
+      </header>
+      <form id="login-form" class="space-y-5" novalidate>
+        <label class="block text-sm">
+          <span class="mb-1 block font-medium text-slate-200">Usuario</span>
+          <input
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+            class="w-full rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+          />
+        </label>
+        <label class="block text-sm">
+          <span class="mb-1 block font-medium text-slate-200">Contraseña</span>
+          <input
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+            class="w-full rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none transition focus:border-teal-400 focus:ring-2 focus:ring-teal-500/40"
+          />
+        </label>
+        <button
+          type="submit"
+          class="w-full rounded-xl bg-teal-400/90 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-teal-300 focus:outline-none focus:ring-2 focus:ring-teal-500/60"
+        >
+          Entrar
+        </button>
+      </form>
+      <p
+        id="login-error"
+        role="alert"
+        class="hidden rounded-xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200"
+      ></p>
+    </div>
+    <p class="max-w-lg text-xs text-slate-500">
+      Si no reconoces esta pantalla ponte en contacto con el equipo de FunTeco. Las credenciales son personales e intransferibles.
+    </p>
+  </section>
+</AdminLayout>
+
+<script type="module" src={adminLoginScript}></script>

--- a/src/scripts/adminLogin.ts
+++ b/src/scripts/adminLogin.ts
@@ -1,0 +1,111 @@
+import { createStrapiAdmin } from "../utils/strapiAdmin";
+import type { StorageLike } from "../utils/adminStore";
+
+export interface AdminLoginOptions {
+  document?: Document;
+  storage?: StorageLike;
+  navigate?: (path: string) => void;
+}
+
+type MessageKind = "info" | "error" | "success";
+
+const getDocument = (doc?: Document) => {
+  if (doc) return doc;
+  if (typeof document !== "undefined") return document;
+  return undefined;
+};
+
+const getStorage = (storage?: StorageLike) => {
+  if (storage) return storage;
+  if (typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage;
+  }
+  return undefined;
+};
+
+const defaultNavigate = (path: string) => {
+  if (typeof window !== "undefined") {
+    window.location.href = path;
+  }
+};
+
+const setMessage = (element: HTMLElement | null, message: string, type: MessageKind = "info") => {
+  if (!element) return;
+  if (!message) {
+    element.classList.add("hidden");
+    element.textContent = "";
+    element.classList.remove("border-rose-500/40", "text-rose-200", "border-teal-500/40", "text-teal-200");
+    return;
+  }
+  element.textContent = message;
+  element.classList.remove("hidden");
+  element.classList.toggle("border-rose-500/40", type === "error");
+  element.classList.toggle("text-rose-200", type === "error");
+  element.classList.toggle("border-teal-500/40", type === "success");
+  element.classList.toggle("text-teal-200", type === "success");
+  if (type === "info") {
+    element.classList.remove("border-rose-500/40", "text-rose-200", "border-teal-500/40", "text-teal-200");
+  }
+};
+
+export const setupAdminLogin = (options: AdminLoginOptions = {}) => {
+  const doc = getDocument(options.document);
+  if (!doc) return;
+  const root = doc.querySelector<HTMLElement>("#admin-login-app");
+  if (!root) return;
+
+  const loginForm = doc.querySelector<HTMLFormElement>("#login-form");
+  const loginError = doc.querySelector<HTMLElement>("#login-error");
+  const storage = getStorage(options.storage);
+  const navigate = options.navigate ?? defaultNavigate;
+  const store = createStrapiAdmin(storage);
+
+  const redirectIfAuthenticated = () => {
+    const currentUser = store.modules.usersRolesPermissions.currentUser();
+    if (currentUser) {
+      setMessage(loginError, "", "info");
+      navigate("/admin");
+      return true;
+    }
+    return false;
+  };
+
+  if (redirectIfAuthenticated()) {
+    return { store };
+  }
+
+  root.dataset.state = "ready";
+
+  loginForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    const username = String(formData.get("username") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+
+    if (!username || !password) {
+      setMessage(loginError, "Introduce un usuario y contraseña válidos.", "error");
+      return;
+    }
+
+    if (password.length < 6) {
+      setMessage(loginError, "La contraseña debe tener al menos 6 caracteres.", "error");
+      return;
+    }
+
+    try {
+      store.login(username, password);
+      loginForm.reset();
+      setMessage(loginError, "", "info");
+      navigate("/admin");
+    } catch (error) {
+      console.warn("Intento de acceso no autorizado", error);
+      setMessage(loginError, "Credenciales incorrectas.", "error");
+    }
+  });
+
+  return { store };
+};
+
+if (typeof window !== "undefined") {
+  setupAdminLogin();
+}

--- a/src/tests/adminDashboard.test.ts
+++ b/src/tests/adminDashboard.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { setupAdminDashboard } from "../scripts/adminDashboard";
+import { createStrapiAdmin } from "../utils/strapiAdmin";
+import type { StorageLike } from "../utils/adminStore";
+
+const createStorage = (): StorageLike => {
+  const map = new Map<string, string>();
+  return {
+    getItem(key) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key, value) {
+      map.set(key, value);
+    },
+    removeItem(key) {
+      map.delete(key);
+    },
+  };
+};
+
+const adminHtml = `
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <div id="admin-app" class="hidden opacity-0" data-auth-state="pending">
+      <section id="dashboard">
+        <header>
+          <span id="current-user"></span>
+          <button id="logout-btn" type="button">Cerrar sesión</button>
+        </header>
+        <nav>
+          <button data-view="content-types" data-active="true" aria-pressed="true"></button>
+        </nav>
+        <div data-view-panel="content-types"></div>
+      </section>
+    </div>
+  </body>
+</html>
+`;
+
+const originalGlobals = {
+  FormData: globalThis.FormData,
+  confirm: globalThis.confirm,
+  alert: globalThis.alert,
+};
+
+const setupDom = () => {
+  const dom = new JSDOM(adminHtml, { url: "https://funteco.test/admin" });
+  (globalThis as unknown as { window: Window }).window = dom.window as unknown as Window;
+  (globalThis as unknown as { document: Document }).document = dom.window.document;
+  (globalThis as unknown as { FormData: typeof FormData }).FormData = dom.window.FormData;
+  (globalThis as unknown as { confirm: (message?: string) => boolean }).confirm = () => true;
+  (globalThis as unknown as { alert: (message?: string) => void }).alert = () => undefined;
+  return dom;
+};
+
+const cleanupDom = (dom: JSDOM) => {
+  dom.window.close();
+  delete (globalThis as { window?: Window }).window;
+  delete (globalThis as { document?: Document }).document;
+  (globalThis as unknown as { FormData: typeof FormData | undefined }).FormData = originalGlobals.FormData;
+  (globalThis as unknown as { confirm: ((message?: string) => boolean) | undefined }).confirm = originalGlobals.confirm;
+  (globalThis as unknown as { alert: ((message?: string) => void) | undefined }).alert = originalGlobals.alert;
+};
+
+describe("admin dashboard", () => {
+  it("redirige a la pantalla de acceso cuando no hay sesión", () => {
+    const dom = setupDom();
+    const storage = createStorage();
+    const navigate = vi.fn();
+
+    setupAdminDashboard({ storage, navigate, suppressRender: true });
+
+    expect(navigate).toHaveBeenCalledWith("/admin/login");
+    const root = dom.window.document.querySelector<HTMLElement>("#admin-app");
+    expect(root?.classList.contains("hidden")).toBe(true);
+
+    cleanupDom(dom);
+  });
+
+  it("muestra el nombre del usuario autenticado y revela el panel", () => {
+    const dom = setupDom();
+    const storage = createStorage();
+    const store = createStrapiAdmin(storage);
+    const user = store.login("admin", "admin123");
+    const navigate = vi.fn();
+
+    setupAdminDashboard({ storage, navigate, suppressRender: true });
+
+    const root = dom.window.document.querySelector<HTMLElement>("#admin-app");
+    const currentUser = dom.window.document.querySelector<HTMLElement>("#current-user");
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(root?.dataset.authState).toBe("ready");
+    expect(root?.classList.contains("hidden")).toBe(false);
+    expect(currentUser?.textContent).toBe(user.username);
+
+    cleanupDom(dom);
+  });
+
+  it("cierra la sesión y redirige al pulsar cerrar sesión", () => {
+    const dom = setupDom();
+    const storage = createStorage();
+    const store = createStrapiAdmin(storage);
+    store.login("admin", "admin123");
+    const navigate = vi.fn();
+
+    setupAdminDashboard({ storage, navigate, suppressRender: true });
+
+    const logoutBtn = dom.window.document.querySelector<HTMLButtonElement>("#logout-btn");
+    expect(logoutBtn).not.toBeNull();
+    logoutBtn!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+
+    expect(navigate).toHaveBeenLastCalledWith("/admin/login");
+    const freshStore = createStrapiAdmin(storage);
+    expect(freshStore.modules.usersRolesPermissions.currentUser()).toBeNull();
+    const root = dom.window.document.querySelector<HTMLElement>("#admin-app");
+    expect(root?.dataset.authState).toBe("signed-out");
+
+    cleanupDom(dom);
+  });
+});

--- a/src/tests/adminLogin.test.ts
+++ b/src/tests/adminLogin.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { setupAdminLogin } from "../scripts/adminLogin";
+import { createStrapiAdmin } from "../utils/strapiAdmin";
+import type { StorageLike } from "../utils/adminStore";
+
+const createStorage = (): StorageLike => {
+  const map = new Map<string, string>();
+  return {
+    getItem(key) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key, value) {
+      map.set(key, value);
+    },
+    removeItem(key) {
+      map.delete(key);
+    },
+  };
+};
+
+const loginHtml = `
+<!DOCTYPE html>
+<html lang="es">
+  <body>
+    <section id="admin-login-app">
+      <form id="login-form">
+        <input name="username" />
+        <input name="password" type="password" />
+        <button type="submit">Entrar</button>
+      </form>
+      <p id="login-error" class="hidden"></p>
+    </section>
+  </body>
+</html>
+`;
+
+const createDom = () => new JSDOM(loginHtml, { url: "https://funteco.test/admin/login" });
+
+const originalFormData = globalThis.FormData;
+
+describe("admin login", () => {
+  it("redirecciona al dashboard cuando ya existe una sesión", () => {
+    const dom = createDom();
+    const storage = createStorage();
+    const store = createStrapiAdmin(storage);
+    store.login("admin", "admin123");
+    const navigate = vi.fn();
+    (globalThis as unknown as { FormData: typeof FormData }).FormData = dom.window.FormData;
+
+    setupAdminLogin({ document: dom.window.document, storage, navigate });
+
+    expect(navigate).toHaveBeenCalledWith("/admin");
+    dom.window.close();
+    (globalThis as unknown as { FormData: typeof FormData | undefined }).FormData = originalFormData;
+  });
+
+  it("muestra un error cuando faltan credenciales", () => {
+    const dom = createDom();
+    const storage = createStorage();
+    const navigate = vi.fn();
+    (globalThis as unknown as { FormData: typeof FormData }).FormData = dom.window.FormData;
+
+    setupAdminLogin({ document: dom.window.document, storage, navigate });
+
+    const form = dom.window.document.querySelector<HTMLFormElement>("#login-form");
+    const error = dom.window.document.querySelector<HTMLElement>("#login-error");
+    expect(form).not.toBeNull();
+    expect(error).not.toBeNull();
+
+    form!.dispatchEvent(new dom.window.Event("submit", { bubbles: true, cancelable: true }));
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(error!.textContent).toContain("Introduce un usuario");
+    expect(error!.classList.contains("hidden")).toBe(false);
+
+    dom.window.close();
+    (globalThis as unknown as { FormData: typeof FormData | undefined }).FormData = originalFormData;
+  });
+
+  it("inicia sesión con credenciales válidas y redirige", () => {
+    const dom = createDom();
+    const storage = createStorage();
+    const navigate = vi.fn();
+    (globalThis as unknown as { FormData: typeof FormData }).FormData = dom.window.FormData;
+
+    setupAdminLogin({ document: dom.window.document, storage, navigate });
+
+    const form = dom.window.document.querySelector<HTMLFormElement>("#login-form");
+    const username = dom.window.document.querySelector<HTMLInputElement>("input[name='username']");
+    const password = dom.window.document.querySelector<HTMLInputElement>("input[name='password']");
+    const error = dom.window.document.querySelector<HTMLElement>("#login-error");
+    expect(form && username && password && error).not.toBeNull();
+
+    username!.value = "admin";
+    password!.value = "admin123";
+
+    form!.dispatchEvent(new dom.window.Event("submit", { bubbles: true, cancelable: true }));
+
+    expect(navigate).toHaveBeenCalledWith("/admin");
+    expect(error!.classList.contains("hidden")).toBe(true);
+
+    dom.window.close();
+    (globalThis as unknown as { FormData: typeof FormData | undefined }).FormData = originalFormData;
+  });
+});


### PR DESCRIPTION
## Summary
- split the admin dashboard and login into distinct pages so the dashboard stays hidden until authentication succeeds
- add a dedicated login script with stronger validation plus dashboard guards that redirect unauthenticated users
- cover the login (security, validation, UI) and admin session flows with new Vitest suites

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68df3973b8788323aca983823a95a521