### PR TITLE
Add Qué hacemos page with editable content and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@ funteco_astro/
 │   ├── pages/
 │   │   ├── index.astro       # Página de inicio (hero, ejes, eventos, CTA)
 │   │   ├── about.astro       # Misión y visión
+│   │   ├── que-hacemos.astro # Programas, etnoeducación y líneas de acción
 │   │   ├── eventos.astro     # Listado de eventos
 │   │   └── contacto.astro    # Información de contacto y formulario
+│   ├── data/
+│   │   ├── eventsFallback.ts # Datos base para eventos
+│   │   ├── team.json         # Perfiles del equipo
+│   │   ├── team.ts           # Tipos y utilidades para el equipo
+│   │   ├── whatWeDo.json     # Contenido editable para "¿Qué hacemos?"
+│   │   └── whatWeDo.ts       # Tipos y fallback del contenido "¿Qué hacemos?"
 │   └── tests/
+│       ├── content.test.ts   # Pruebas del helper de contenido y copias seguras
 │       └── design.test.js    # Pruebas básicas de diseño
 └── README.md
 ```
@@ -67,9 +75,9 @@ Una vez instaladas las dependencias, puedes ejecutar los siguientes comandos:
 
 ## Gestión de contenido
 
-Los eventos y perfiles del equipo se almacenan en archivos locales dentro de `src/data`. Las utilidades de `src/utils/content.ts` exponen funciones asíncronas para recuperar la información ya normalizada y lista para usarse en las páginas de Astro. Esta aproximación elimina la dependencia de un CMS y facilita desplegar el sitio en entornos estáticos sin variables de entorno especiales.
+Los eventos, los perfiles del equipo y el contenido de la página **¿Qué hacemos?** se almacenan en archivos locales dentro de `src/data`. Las utilidades de `src/utils/content.ts` exponen funciones asíncronas para recuperar la información ya normalizada y lista para usarse en las páginas de Astro. Esta aproximación elimina la dependencia de un CMS y facilita desplegar el sitio en entornos estáticos sin variables de entorno especiales.
 
-Si necesitas actualizar la agenda o los perfiles, edita los archivos `eventsFallback.ts` y `team.json`. Cada función devuelve copias independientes de los datos para evitar mutaciones accidentales en tiempo de ejecución.
+Si necesitas actualizar la agenda, los perfiles o describir nuevos programas, edita los archivos `eventsFallback.ts`, `team.json` y `whatWeDo.json`. Cada función devuelve copias independientes de los datos para evitar mutaciones accidentales en tiempo de ejecución.
 
 El acceso administrativo ahora se concentra en la página `/admin/login`, que ofrece un formulario preparado para conectar con el sistema de autenticación que utilice tu organización. Puedes adaptar la acción del formulario o integrar un servicio de identidad sin modificar el resto del sitio.
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,6 +28,18 @@ const { current = '/' } = Astro.props;
       </li>
       <li>
         <a
+          href="/que-hacemos"
+          class={`pb-1 transition-colors duration-200 ${
+            current === '/que-hacemos'
+              ? 'text-primary-dark border-b-2 border-accent-flamingo'
+              : 'hover:text-primary-dark'
+          }`}
+        >
+          Qué hacemos
+        </a>
+      </li>
+      <li>
+        <a
           href="/eventos"
           class={`pb-1 transition-colors duration-200 ${
             current === '/eventos' ? 'text-primary-dark border-b-2 border-accent-flamingo' : 'hover:text-primary-dark'
@@ -63,6 +75,7 @@ const { current = '/' } = Astro.props;
   <div id="mobile-menu" class="md:hidden hidden px-4 pb-4 bg-white/90 backdrop-blur">
     <a href="/" class={`block py-2 border-b border-accent-blush ${current === '/' ? 'text-primary-dark font-semibold' : ''}`} aria-current={current === '/' ? 'page' : undefined}>Inicio</a>
     <a href="/about" class={`block py-2 border-b border-accent-blush ${current === '/about' ? 'text-primary-dark font-semibold' : ''}`} aria-current={current === '/about' ? 'page' : undefined}>Nosotras</a>
+    <a href="/que-hacemos" class={`block py-2 border-b border-accent-blush ${current === '/que-hacemos' ? 'text-primary-dark font-semibold' : ''}`} aria-current={current === '/que-hacemos' ? 'page' : undefined}>Qué hacemos</a>
     <a href="/eventos" class={`block py-2 border-b border-accent-blush ${current === '/eventos' ? 'text-primary-dark font-semibold' : ''}`} aria-current={current === '/eventos' ? 'page' : undefined}>Eventos</a>
     <a href="/contacto" class={`block py-2 ${current === '/contacto' ? 'text-primary-dark font-semibold' : ''}`} aria-current={current === '/contacto' ? 'page' : undefined}>Contacto</a>
   </div>

--- a/src/data/whatWeDo.json
+++ b/src/data/whatWeDo.json
@@ -1,0 +1,107 @@
+{
+  "hero": {
+    "badge": "Programas vivos",
+    "title": "¿Qué hacemos en Funteco?",
+    "description": "Conectamos investigación, etnoeducación y acción comunitaria para garantizar derechos y bienestar en los territorios afroecuatorianos.",
+    "callout": "Cada proyecto nace del diálogo con lideresas, juventudes y sabedoras que sostienen redes de cuidado." 
+  },
+  "approach": {
+    "title": "Nuestra forma de tejer cambios",
+    "paragraphs": [
+      "Acompañamos procesos que defienden la vida digna, la memoria y la autonomía de los pueblos afrodescendientes.",
+      "Creemos en el poder de la colaboración radical. Trabajamos junto a organizaciones barriales, instituciones educativas y colectivos culturales para amplificar sus agendas." 
+    ],
+    "values": [
+      {
+        "title": "Investigación situada",
+        "description": "Generamos datos, relatos y mapas que visibilizan desigualdades y oportunidades desde las voces afro." 
+      },
+      {
+        "title": "Cuidado colectivo",
+        "description": "Acompañamos procesos psicosociales y económicos que fortalecen la autonomía de las mujeres y familias." 
+      },
+      {
+        "title": "Incidencia creativa",
+        "description": "Diseñamos campañas culturales y prototipos tecnológicos para transformar políticas públicas." 
+      }
+    ]
+  },
+  "focusAreas": [
+    {
+      "title": "Etnoeducación viva",
+      "description": "Integrar saberes ancestrales y metodologías críticas en escuelas, comunidades y espacios digitales.",
+      "emphasis": "Acompañamos a docentes y liderazgos juveniles para crear currículos con perspectiva afro." 
+    },
+    {
+      "title": "Economías solidarias",
+      "description": "Impulsamos emprendimientos liderados por mujeres afro que generan ingresos y redes de apoyo.",
+      "emphasis": "Mentorías, acceso a mercados y laboratorios de innovación financiera comunitaria." 
+    },
+    {
+      "title": "Justicia racial y movilidad",
+      "description": "Defendemos los derechos de personas afro en movilidad humana y promovemos políticas antirracistas.",
+      "emphasis": "Formaciones legales, campañas comunicacionales y articulación con redes de protección." 
+    }
+  ],
+  "etnoeducation": {
+    "title": "Etnoeducación que se siente y se aprende",
+    "description": "La etnoeducación es el corazón de nuestra propuesta pedagógica: un proceso para reconocer la historia afro, sanar violencias y construir futuros tecnológicos propios.",
+    "initiatives": [
+      {
+        "name": "Escuela itinerante de saberes",
+        "impact": "Laboratorios móviles que recorren territorios con recursos didácticos, bibliotecas vivas y talleres de arte y tecnología." 
+      },
+      {
+        "name": "Residencias docentes",
+        "impact": "Acompañamiento a maestras y maestros para transformar currículos, evaluar aprendizajes y crear materiales con enfoque afro." 
+      },
+      {
+        "name": "Plataforma digital etnoeducativa",
+        "impact": "Un repositorio abierto de guías, podcasts y experiencias de aula creadas junto a comunidades afrodescendientes." 
+      }
+    ],
+    "quote": {
+      "text": "La etnoeducación nos permite nombrarnos desde la dignidad y proyectar futuros en donde las niñas afro lideran la innovación.",
+      "author": "Lina Morales",
+      "role": "Coordinadora pedagógica de Funteco" 
+    }
+  },
+  "programs": [
+    {
+      "name": "Laboratorio de innovación comunitaria",
+      "audience": "Juventudes afro entre 16 y 25 años",
+      "focus": "Prototipado de soluciones tecnológicas y artísticas para problemas territoriales",
+      "outcomes": [
+        "Proyectos acompañados por mentoras tecnológicas",
+        "Fondos semilla para iniciativas seleccionadas",
+        "Red de pares y aliadas regionales"
+      ]
+    },
+    {
+      "name": "Rutas de cuidado y protección",
+      "audience": "Mujeres migrantes y refugiadas",
+      "focus": "Fortalecimiento jurídico, psicosocial y económico para mujeres en movilidad",
+      "outcomes": [
+        "Mapeo de servicios seguros",
+        "Clínicas legales itinerantes",
+        "Bolsas solidarias y economías comunitarias"
+      ]
+    },
+    {
+      "name": "Escuela de narrativas afro",
+      "audience": "Comunicadoras, artistas y activistas",
+      "focus": "Producción de contenidos multimedia antirracistas",
+      "outcomes": [
+        "Mentorías en storytelling y podcast",
+        "Equipos portátiles compartidos",
+        "Alianzas con medios comprometidos"
+      ]
+    }
+  ],
+  "cta": {
+    "title": "¿Quieres activar un programa en tu territorio?",
+    "description": "Diseñamos procesos a la medida junto a organizaciones, escuelas y gobiernos locales. Hagamos equipo para que la justicia racial sea política pública y vida cotidiana.",
+    "buttonLabel": "Escríbenos",
+    "buttonUrl": "/contacto"
+  }
+}

--- a/src/data/whatWeDo.ts
+++ b/src/data/whatWeDo.ts
@@ -1,0 +1,60 @@
+import whatWeDoData from "./whatWeDo.json";
+
+export type ValueStatement = {
+  title: string;
+  description: string;
+};
+
+export type FocusArea = {
+  title: string;
+  description: string;
+  emphasis: string;
+};
+
+export type EtnoeducationInitiative = {
+  name: string;
+  impact: string;
+};
+
+export type EtnoeducationQuote = {
+  text: string;
+  author: string;
+  role: string;
+};
+
+export type ProgramOverview = {
+  name: string;
+  audience: string;
+  focus: string;
+  outcomes: string[];
+};
+
+export type WhatWeDoContent = {
+  hero: {
+    badge: string;
+    title: string;
+    description: string;
+    callout: string;
+  };
+  approach: {
+    title: string;
+    paragraphs: string[];
+    values: ValueStatement[];
+  };
+  focusAreas: FocusArea[];
+  etnoeducation: {
+    title: string;
+    description: string;
+    initiatives: EtnoeducationInitiative[];
+    quote: EtnoeducationQuote;
+  };
+  programs: ProgramOverview[];
+  cta: {
+    title: string;
+    description: string;
+    buttonLabel: string;
+    buttonUrl: string;
+  };
+};
+
+export const fallbackWhatWeDoContent = whatWeDoData as WhatWeDoContent;

--- a/src/pages/que-hacemos.astro
+++ b/src/pages/que-hacemos.astro
@@ -1,0 +1,145 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import { getWhatWeDoContent, type WhatWeDoContent } from "../utils/content";
+
+const content: WhatWeDoContent = await getWhatWeDoContent();
+const pageTitle = "¿Qué hacemos";
+const description =
+  "Explora los programas, la etnoeducación y las alianzas que impulsa Funteco para transformar los territorios afro";
+---
+<BaseLayout title={pageTitle} description={description} canonical="https://www.fundaciontejiendoconocimiento.com/que-hacemos">
+  <Header current="/que-hacemos" />
+  <main class="bg-gradient-to-br from-neutral via-white to-accent-blush/20">
+    <section class="relative overflow-hidden py-20">
+      <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(244,140,6,0.12),_transparent_60%)]"></div>
+      <div class="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <span class="inline-flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-dark shadow-sm">
+          {content.hero.badge}
+          <span class="inline-flex h-2 w-2 rounded-full bg-panafrican-red animate-pulse" aria-hidden="true"></span>
+        </span>
+        <div class="mt-8 grid gap-10 lg:grid-cols-[minmax(0,_1.2fr)_minmax(0,_0.8fr)] items-start">
+          <div class="space-y-6">
+            <h1 class="text-4xl sm:text-5xl font-bold text-primary-dark leading-tight">
+              {content.hero.title}
+            </h1>
+            <p class="text-lg text-neutral-black/80 leading-relaxed">
+              {content.hero.description}
+            </p>
+            <div class="rounded-3xl border border-accent-blush/40 bg-white/90 p-6 shadow-lg text-sm text-neutral-black/80">
+              {content.hero.callout}
+            </div>
+          </div>
+          <div class="grid gap-4">
+            {content.approach.values.map((value) => (
+              <div class="rounded-3xl border border-primary/10 bg-gradient-to-br from-white via-white to-accent-blush/40 p-6 shadow-md">
+                <h2 class="text-base font-semibold uppercase tracking-[0.3em] text-primary-dark/80">
+                  {value.title}
+                </h2>
+                <p class="mt-3 text-sm text-neutral-black/80 leading-relaxed">
+                  {value.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="pb-20">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="max-w-3xl space-y-4">
+          <h2 class="text-3xl font-semibold text-primary-dark">{content.approach.title}</h2>
+          {content.approach.paragraphs.map((paragraph) => (
+            <p class="text-base text-neutral-black/80 leading-relaxed">{paragraph}</p>
+          ))}
+        </div>
+        <div class="mt-14 grid gap-8 md:grid-cols-3">
+          {content.focusAreas.map((area) => (
+            <article class="group relative overflow-hidden rounded-3xl border border-primary/10 bg-white/95 p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl">
+              <div class="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary via-accent to-panafrican-green" aria-hidden="true"></div>
+              <h3 class="text-xl font-semibold text-primary-dark">{area.title}</h3>
+              <p class="mt-4 text-sm text-neutral-black/80 leading-relaxed">{area.description}</p>
+              <p class="mt-6 text-sm font-semibold text-accent">{area.emphasis}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="relative bg-gradient-to-br from-primary-dark via-primary to-accent text-white py-20">
+      <div class="absolute inset-x-6 inset-y-0 rounded-3xl border border-white/20"></div>
+      <div class="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 grid gap-12 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_1.2fr)] items-center">
+        <div class="space-y-6">
+          <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em]">
+            Etnoeducación
+          </span>
+          <h2 class="text-3xl font-semibold leading-snug">{content.etnoeducation.title}</h2>
+          <p class="text-base text-white/85 leading-relaxed">{content.etnoeducation.description}</p>
+          <blockquote class="rounded-3xl border border-white/20 bg-white/10 p-6 text-sm italic leading-relaxed">
+            “{content.etnoeducation.quote.text}”
+            <footer class="mt-4 not-italic text-xs font-semibold uppercase tracking-[0.3em] text-white/80">
+              {content.etnoeducation.quote.author} · {content.etnoeducation.quote.role}
+            </footer>
+          </blockquote>
+        </div>
+        <div class="grid gap-6">
+          {content.etnoeducation.initiatives.map((initiative) => (
+            <div class="rounded-3xl border border-white/20 bg-white/10 p-6 shadow-lg">
+              <h3 class="text-lg font-semibold">{initiative.name}</h3>
+              <p class="mt-3 text-sm text-white/85 leading-relaxed">{initiative.impact}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="py-20">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center max-w-3xl mx-auto space-y-4">
+          <span class="inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-dark shadow-sm">
+            Programas
+          </span>
+          <h2 class="text-3xl font-semibold text-primary-dark">Conoce nuestras líneas de trabajo</h2>
+          <p class="text-base text-neutral-black/75">
+            Cada programa se diseña con metodologías participativas y resultados medibles que fortalecen las redes afro.
+          </p>
+        </div>
+        <div class="mt-14 grid gap-8 md:grid-cols-3">
+          {content.programs.map((program) => (
+            <article class="flex h-full flex-col rounded-3xl border border-primary/15 bg-white/95 p-8 shadow-lg">
+              <div>
+                <h3 class="text-xl font-semibold text-primary-dark">{program.name}</h3>
+                <p class="mt-3 text-sm text-neutral-black/70">{program.audience}</p>
+                <p class="mt-4 text-sm text-neutral-black/80 leading-relaxed">{program.focus}</p>
+              </div>
+              <ul class="mt-6 space-y-3 text-sm text-neutral-black/80">
+                {program.outcomes.map((outcome) => (
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-accent" aria-hidden="true"></span>
+                    <span>{outcome}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="pb-24">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
+        <h2 class="text-3xl font-semibold text-primary-dark">{content.cta.title}</h2>
+        <p class="text-base text-neutral-black/80 leading-relaxed">{content.cta.description}</p>
+        <a
+          href={content.cta.buttonUrl}
+          class="inline-flex items-center justify-center rounded-full bg-primary px-8 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-accent"
+        >
+          {content.cta.buttonLabel}
+        </a>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/tests/content.test.ts
+++ b/src/tests/content.test.ts
@@ -6,7 +6,9 @@ import {
   getEvents,
   getTeamMemberBySlug,
   getTeamMembers,
+  getWhatWeDoContent,
 } from "../utils/content";
+import { fallbackWhatWeDoContent } from "../data/whatWeDo";
 
 describe("content helpers", () => {
   it("devuelve copias independientes de los eventos", async () => {
@@ -53,5 +55,14 @@ describe("content helpers", () => {
     const member = await getTeamMemberBySlug(target.slug);
     expect(member).toEqual(target);
     expect(member).not.toBe(target);
+  });
+
+  it("devuelve contenido editable para la página ¿Qué hacemos?", async () => {
+    const content = await getWhatWeDoContent();
+    expect(content).toEqual(fallbackWhatWeDoContent);
+    expect(content).not.toBe(fallbackWhatWeDoContent);
+    expect(content.etnoeducation.title.toLowerCase()).toContain("etnoeducación".toLowerCase());
+    content.programs[0]?.outcomes.push("nuevo resultado");
+    expect(fallbackWhatWeDoContent.programs[0]?.outcomes).not.toContain("nuevo resultado");
   });
 });

--- a/src/tests/design.test.js
+++ b/src/tests/design.test.js
@@ -11,11 +11,12 @@ describe('Diseño de páginas', () => {
     expect(heading.textContent?.toUpperCase()).toContain('IMPULSANDO');
   });
   it('La navegación incluye enlaces principales', () => {
-    const navHtml = `<!DOCTYPE html><html><body><nav><a href="/">Inicio</a><a href="/about">Nosotras</a><a href="/eventos">Eventos</a><a href="/contacto">Contacto</a></nav></body></html>`;
+    const navHtml = `<!DOCTYPE html><html><body><nav><a href="/">Inicio</a><a href="/about">Nosotras</a><a href="/que-hacemos">Qué hacemos</a><a href="/eventos">Eventos</a><a href="/contacto">Contacto</a></nav></body></html>`;
     const dom = new JSDOM(navHtml);
     const links = Array.from(dom.window.document.querySelectorAll('nav a')).map(el => el.textContent);
     expect(links).toContain('Inicio');
     expect(links).toContain('Nosotras');
+    expect(links).toContain('Qué hacemos');
     expect(links).toContain('Eventos');
     expect(links).toContain('Contacto');
   });

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -8,6 +8,10 @@ import {
   getFallbackTeamMemberBySlug,
   type TeamMember,
 } from "../data/team";
+import {
+  fallbackWhatWeDoContent,
+  type WhatWeDoContent,
+} from "../data/whatWeDo";
 
 const cloneEvent = (event: Event): Event => ({
   ...event,
@@ -21,6 +25,29 @@ const cloneTeamMember = (member: TeamMember): TeamMember => ({
   expertise: [...member.expertise],
   highlights: [...member.highlights],
   socials: member.socials.map((social) => ({ ...social })),
+});
+
+const cloneWhatWeDo = (content: WhatWeDoContent): WhatWeDoContent => ({
+  hero: { ...content.hero },
+  approach: {
+    title: content.approach.title,
+    paragraphs: [...content.approach.paragraphs],
+    values: content.approach.values.map((value) => ({ ...value })),
+  },
+  focusAreas: content.focusAreas.map((area) => ({ ...area })),
+  etnoeducation: {
+    title: content.etnoeducation.title,
+    description: content.etnoeducation.description,
+    initiatives: content.etnoeducation.initiatives.map((initiative) => ({
+      ...initiative,
+    })),
+    quote: { ...content.etnoeducation.quote },
+  },
+  programs: content.programs.map((program) => ({
+    ...program,
+    outcomes: [...program.outcomes],
+  })),
+  cta: { ...content.cta },
 });
 
 export async function getEvents(): Promise<Event[]> {
@@ -44,3 +71,9 @@ export async function getTeamMemberBySlug(
 }
 
 export type { Event, TeamMember };
+
+export async function getWhatWeDoContent(): Promise<WhatWeDoContent> {
+  return cloneWhatWeDo(fallbackWhatWeDoContent);
+}
+
+export type { WhatWeDoContent };


### PR DESCRIPTION
## Summary
- add a new `/que-hacemos` page styled to match eventos with hero, focus areas, etnoeducación section and CTA
- expose editable content for the new page through `src/data/whatWeDo.json` and safe helpers
- update navigation, documentation and tests to reference the new page and data source

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e93e446a2c8323ad34ea96af2b1b99