### PR TITLE
Actualiza imágenes locales y agrega enlace al dossier

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,6 +16,16 @@ const currentYear = new Date().getFullYear();
         <li>Alfonso Perrier 2278, Quito 170136, Ecuador</li>
         <li><a href="mailto:fundaciontejiendoc@gmail.com" class="hover:text-white transition">fundaciontejiendoc@gmail.com</a></li>
         <li>+593 97 989 3376</li>
+        <li>
+          <a
+            href="/Docs/FUNDACI%C3%93N%20TEJIENDO%20CONOCIMIENTO.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="hover:text-white transition"
+          >
+            Descargar dossier institucional (PDF)
+          </a>
+        </li>
       </ul>
     </div>
     <div>

--- a/src/data/eventsFallback.ts
+++ b/src/data/eventsFallback.ts
@@ -22,7 +22,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2025-05-18',
     formattedDate: '18 de mayo de 2025',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/13.jpg',
+    image: '/images/13.jpg',
     location: 'Casa de la Cultura Ecuatoriana, Quito',
     tags: ['formación', 'derechos humanos']
   },
@@ -37,7 +37,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2025-10-02',
     formattedDate: '2 de octubre de 2025',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/14.jpg',
+    image: '/images/14.jpg',
     location: 'Universidad Andina Simón Bolívar, Quito',
     tags: ['investigación', 'política pública']
   },
@@ -52,7 +52,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2025-12-12',
     formattedDate: '12 de diciembre de 2025',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/15.jpeg',
+    image: '/images/15.jpeg',
     location: 'Malecón 2000, Guayaquil',
     tags: ['cultura', 'comunidad']
   },
@@ -67,7 +67,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2026-01-20',
     formattedDate: '20 de enero de 2026',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/16.jpg',
+    image: '/images/16.jpg',
     location: 'Centro Cultural Metropolitano, Quito',
     tags: ['identidad', 'memoria']
   },
@@ -82,7 +82,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2026-03-15',
     formattedDate: '15 de marzo de 2026',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/courses-1.jpg',
+    image: '/images/funteco4.png',
     location: 'Centro de Innovación Social, Esmeraldas',
     tags: ['liderazgo', 'juventudes']
   },
@@ -97,7 +97,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2026-05-08',
     formattedDate: '8 de mayo de 2026',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/12.jpg',
+    image: '/images/funteco5.png',
     location: 'Centro Cultural de Ibarra, Ibarra',
     tags: ['género', 'justicia racial']
   },
@@ -112,7 +112,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2026-07-24',
     formattedDate: '24 de julio de 2026',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/14.jpg',
+    image: '/images/306949967_462749855876866_8219731164686257448_n.jpg',
     location: 'Parque La Carolina, Quito',
     tags: ['emprendimiento', 'economía solidaria']
   },
@@ -127,7 +127,7 @@ export const fallbackEvents: Event[] = [
     ],
     date: '2026-11-19',
     formattedDate: '19 de noviembre de 2026',
-    image: 'https://raw.githubusercontent.com/DerianDev17/Funteco/main/img/15.jpeg',
+    image: '/images/zyro-image.png',
     location: 'Teatro Sánchez Aguilar, Samborondón',
     tags: ['música', 'juventudes']
   }

--- a/src/data/team.json
+++ b/src/data/team.json
@@ -3,7 +3,7 @@
     "slug": "nieves-mendez-olaya",
     "name": "Nieves Méndez Olaya",
     "role": "Socia fundadora",
-    "image": "/images/team-nieves.svg",
+    "image": "/images/nievesFunteco.jpg",
     "shortBio": "Trabajadora social con dos décadas de acompañamiento a familias afrocolombianas y ecuatorianas en procesos de cuidado comunitario.",
     "bio": [
       "Nieves es trabajadora social y tejedora comunitaria. Durante los últimos veinte años ha acompañado a familias afrocolombianas y ecuatorianas que viven procesos de movilidad humana, priorizando la salud mental, el acceso a derechos y la construcción de redes de autocuidado colectivo.",
@@ -37,7 +37,7 @@
     "slug": "diana-angulo-balanta",
     "name": "Diana Angulo Balanta",
     "role": "Socia fundadora",
-    "image": "/images/team-diana.svg",
+    "image": "/images/funtecoDiana.png",
     "shortBio": "Comunicadora y gestora cultural afrocolombiana. Impulsa procesos de memoria y narrativas audiovisuales con juventudes afro.",
     "bio": [
       "Diana es comunicadora social y productora audiovisual. Ha trabajado con colectivos juveniles afro en Colombia y Ecuador para documentar historias de resistencia, migración y creatividad afrodescendiente a través de podcasts, documentales y performances urbanos.",
@@ -71,7 +71,7 @@
     "slug": "elizabeth-mendez-grueso",
     "name": "Elizabeth Méndez Grueso",
     "role": "Socia fundadora",
-    "image": "/images/team-elizabeth.svg",
+    "image": "/images/funtecoElizabeth.png",
     "shortBio": "Economista popular que acompaña emprendimientos liderados por mujeres afro en Quito y Esmeraldas con enfoque solidario.",
     "bio": [
       "Elizabeth es economista popular y asesora en finanzas comunitarias. Acompaña emprendimientos liderados por mujeres afro, promoviendo modelos económicos solidarios que priorizan el bienestar colectivo y la redistribución justa del trabajo de cuidados.",
@@ -105,7 +105,7 @@
     "slug": "francia-jenny-moreno",
     "name": "Francia Jenny Moreno",
     "role": "Coordinadora de proyectos",
-    "image": "/images/team-francia.svg",
+    "image": "/images/FranciaFunteco.jpeg",
     "shortBio": "Ingeniera en desarrollo local con experiencia en gestión de fondos y programas con enfoque interseccional en Ecuador.",
     "bio": [
       "Francia es ingeniera en desarrollo local y gestora de proyectos sociales con enfoque interseccional. Ha coordinado iniciativas de justicia racial, movilidad humana y prevención de violencias en alianza con organizaciones comunitarias e instituciones públicas.",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,7 @@ const {
 } = Astro.props;
 
 const seoTitle = title ? `${title} | Funteco` : 'Funteco';
-const ogImagePath = '/images/og-funteco.svg';
+const ogImagePath = '/images/FuntecoLogo2024.jpg';
 const ogImage = Astro.site ? new URL(ogImagePath, Astro.site).href : ogImagePath;
 ---
 <!DOCTYPE html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,8 +82,8 @@ const learningJourney = [
             <div class="absolute -inset-6 bg-gradient-to-br from-accent-flamingo/60 via-primary/40 to-primary-dark/50 blur-3xl opacity-70"></div>
             <div class="relative rounded-[3rem] border-8 border-white shadow-2xl overflow-hidden max-w-3xl">
               <img
-                src="/images/etnoeducacion-hero.svg"
-                alt="Ilustración abstracta que representa la red etnoeducativa de Funteco"
+                src="/images/funtecoEvento2.jpg"
+                alt="Equipo de Funteco facilitando un encuentro comunitario"
                 class="w-full object-cover"
               />
             </div>
@@ -130,8 +130,8 @@ const learningJourney = [
           <div class="absolute -inset-6 rounded-[3rem] bg-gradient-to-br from-primary/30 via-accent/30 to-panafrican-green/25 blur-3xl"></div>
           <div class="relative rounded-[3rem] border border-primary/10 bg-white/95 shadow-2xl overflow-hidden">
             <img
-              src="/images/etnoeducacion-encuentro.svg"
-              alt="Ilustración de un círculo comunitario de etnoeducación"
+              src="/images/funtecoEvento.jpg"
+              alt="Participantes reunidas durante un taller de etnoeducación"
               class="w-full object-cover"
               loading="lazy"
             />


### PR DESCRIPTION
## Summary
- reemplazar las ilustraciones del home por fotografías de la nueva carpeta public/images
- apuntar los eventos y perfiles de equipo a imágenes locales y actualizar la imagen OG
- exponer el dossier institucional en el pie de página

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e9592241348323a9cef9ac77be735b